### PR TITLE
環境変数をリストとし、関数を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ LIBFT_DIR	:= libft
 LIBFT		:= $(LIBFT_DIR)/libft.a
 INC			:= -I$(INC_DIR) -I$(LIBFT_DIR)
 
-SRCS		:= srcs/utils/env.c srcs/utils/error.c srcs/main.c srcs/exec/exec_command.c srcs/builtin/buildin.c
+SRCS		:= srcs/utils/env.c srcs/utils/error.c srcs/utils/env_utils.c srcs/main.c srcs/exec/exec_command.c srcs/builtin/buildin.c 
 OBJS		:= $(SRCS:%.c=%.o)
 LIBS		:= -lft -L$(LIBFT_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+         #
+#    By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2021/02/10 18:36:52 by nfukada           #+#    #+#              #
-#    Updated: 2021/02/12 14:27:52 by totaisei         ###   ########.fr        #
+#    Updated: 2021/02/14 01:10:28 by nfukada          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -18,7 +18,7 @@ LIBFT_DIR	:= libft
 LIBFT		:= $(LIBFT_DIR)/libft.a
 INC			:= -I$(INC_DIR) -I$(LIBFT_DIR)
 
-SRCS		:= srcs/utils/error.c srcs/main.c srcs/exec/exec_command.c srcs/builtin/buildin.c 
+SRCS		:= srcs/utils/env.c srcs/utils/error.c srcs/main.c srcs/exec/exec_command.c srcs/builtin/buildin.c
 OBJS		:= $(SRCS:%.c=%.o)
 LIBS		:= -lft -L$(LIBFT_DIR)
 

--- a/includes/exec.h
+++ b/includes/exec.h
@@ -6,13 +6,15 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 20:07:01 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/12 20:07:05 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/13 23:37:03 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef EXEC_H
 # define EXEC_H
 
-void	exec_command(char **args, char **envp);
+# include "utils.h"
+
+void	exec_command(char **args, t_env *envs);
 
 #endif

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 20:13:16 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/14 01:10:45 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/14 01:14:40 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,11 @@ typedef struct	s_env
 
 void			error_exit(void);
 
+t_env			*create_envs_from_environ(void);
 void			print_envs(t_env *envs);
+void			add_env(t_env **envs, t_env *new_env);
+
+t_env			*get_last_env(t_env *envs);
+t_env			*create_new_env(char *env_str);
 
 #endif

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -6,12 +6,14 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 20:13:16 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/14 01:15:44 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/14 01:19:50 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef UTILS_H
 # define UTILS_H
+
+# include <stddef.h>
 
 typedef struct	s_env
 {
@@ -26,8 +28,10 @@ t_env			*create_envs_from_environ(void);
 void			print_envs(t_env *envs);
 char			**generate_environ(t_env *envs);
 void			add_env(t_env **envs, t_env *new_env);
+void			del_env(t_env **envs, char *name);
 
 t_env			*get_last_env(t_env *envs);
+size_t			get_env_size(t_env *envs);
 t_env			*create_new_env(char *env_str);
 
 #endif

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -6,13 +6,20 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 20:13:16 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/12 20:13:19 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/13 23:35:38 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef UTILS_H
 # define UTILS_H
 
-void	error_exit(void);
+typedef struct	s_env
+{
+	char			*name;
+	char			*value;
+	struct s_env	*next;
+}				t_env;
+
+void			error_exit(void);
 
 #endif

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 20:13:16 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/14 01:14:40 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/14 01:15:44 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,7 @@ void			error_exit(void);
 
 t_env			*create_envs_from_environ(void);
 void			print_envs(t_env *envs);
+char			**generate_environ(t_env *envs);
 void			add_env(t_env **envs, t_env *new_env);
 
 t_env			*get_last_env(t_env *envs);

--- a/srcs/exec/exec_command.c
+++ b/srcs/exec/exec_command.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 17:59:52 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/12 20:14:07 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/14 01:21:43 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,7 @@
 #include "builtin.h"
 #include "utils.h"
 
-void	exec_command(char **args, char **envp)
+void	exec_command(char **args, t_env *envs)
 {
 	pid_t	pid;
 	int		status;
@@ -31,7 +31,7 @@ void	exec_command(char **args, char **envp)
 		error_exit();
 	if (pid == 0)
 	{
-		if (execve(args[0], args, envp) < 0)
+		if (execve(args[0], args, generate_environ(envs)) < 0)
 			error_exit();
 	}
 	else

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/10 18:50:22 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/12 22:37:07 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/14 00:57:55 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,7 @@ void	free_array(char **array)
 	array = NULL;
 }
 
-void	loop_shell(char **envp)
+void	loop_shell(t_env *envs)
 {
 	int		status;
 	char	*line;
@@ -44,14 +44,17 @@ void	loop_shell(char **envp)
 		if ((args = ft_split(line, ' ')) == NULL)
 			error_exit();
 		free(line);
-		exec_command(args, envp);
+		exec_command(args, envs);
 		free_array(args);
 	}
 }
 
-int		main(int argc, char *argv[], char *envp[])
+int		main(int argc, char *argv[])
 {
+	t_env	*envs;
+
 	(void)argc;
 	(void)argv;
-	loop_shell(envp);
+	envs = create_envs_from_environ();
+	loop_shell(envs);
 }

--- a/srcs/utils/env.c
+++ b/srcs/utils/env.c
@@ -1,27 +1,26 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   utils.h                                            :+:      :+:    :+:   */
+/*   env.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2021/02/12 20:13:16 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/14 01:10:45 by nfukada          ###   ########.fr       */
+/*   Created: 2021/02/13 19:17:58 by nfukada           #+#    #+#             */
+/*   Updated: 2021/02/14 01:09:48 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef UTILS_H
-# define UTILS_H
+#include "utils.h"
+#include "libft.h"
 
-typedef struct	s_env
+void	print_envs(t_env *envs)
 {
-	char			*name;
-	char			*value;
-	struct s_env	*next;
-}				t_env;
-
-void			error_exit(void);
-
-void			print_envs(t_env *envs);
-
-#endif
+	while (envs)
+	{
+		ft_putstr_fd(envs->name, STDOUT_FILENO);
+		ft_putchar_fd('=', STDOUT_FILENO);
+		ft_putstr_fd(envs->value, STDOUT_FILENO);
+		ft_putchar_fd('\n', STDOUT_FILENO);
+		envs = envs->next;
+	}
+}

--- a/srcs/utils/env.c
+++ b/srcs/utils/env.c
@@ -6,12 +6,30 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/13 19:17:58 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/14 01:09:48 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/14 01:12:35 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "utils.h"
 #include "libft.h"
+
+t_env	*create_envs_from_environ(void)
+{
+	extern char	**environ;
+	size_t		i;
+	t_env		*envs;
+	t_env		*now_env;
+
+	envs = NULL;
+	i = 0;
+	while (environ[i])
+	{
+		now_env = create_new_env(environ[i]);
+		add_env(&envs, now_env);
+		i++;
+	}
+	return (envs);
+}
 
 void	print_envs(t_env *envs)
 {
@@ -22,5 +40,18 @@ void	print_envs(t_env *envs)
 		ft_putstr_fd(envs->value, STDOUT_FILENO);
 		ft_putchar_fd('\n', STDOUT_FILENO);
 		envs = envs->next;
+	}
+}
+
+void	add_env(t_env **envs, t_env *new_env)
+{
+	if (!new_env || !envs)
+		return ;
+	if (!*envs)
+		*envs = new_env;
+	else
+	{
+		get_last_env(*envs)->next = new_env;
+		new_env->next = NULL;
 	}
 }

--- a/srcs/utils/env.c
+++ b/srcs/utils/env.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/13 19:17:58 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/14 01:19:23 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/14 13:53:15 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,6 +46,7 @@ void	print_envs(t_env *envs)
 char	**generate_environ(t_env *envs)
 {
 	char	**environ;
+	char	*tmp;
 	size_t	env_size;
 	size_t	i;
 
@@ -58,8 +59,10 @@ char	**generate_environ(t_env *envs)
 	{
 		if (!(environ[i] = ft_strjoin(envs->name, "=")))
 			error_exit();
+		tmp = environ[i];
 		if (!(environ[i] = ft_strjoin(environ[i], envs->value)))
 			error_exit();
+		free(tmp);
 		i++;
 		envs = envs->next;
 	}

--- a/srcs/utils/env.c
+++ b/srcs/utils/env.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/13 19:17:58 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/14 01:16:09 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/14 01:19:23 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -77,5 +77,27 @@ void	add_env(t_env **envs, t_env *new_env)
 	{
 		get_last_env(*envs)->next = new_env;
 		new_env->next = NULL;
+	}
+}
+
+void	del_env(t_env **envs, char *name)
+{
+	t_env	*now;
+	t_env	*prev;
+
+	prev = NULL;
+	now = *envs;
+	while (now)
+	{
+		if (ft_strncmp(now->name, name, ft_strlen(name) + 1) == 0)
+		{
+			if (prev)
+				prev->next = now->next;
+			else
+				*envs = now->next;
+			free(now);
+		}
+		prev = now;
+		now = now->next;
 	}
 }

--- a/srcs/utils/env.c
+++ b/srcs/utils/env.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/13 19:17:58 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/14 01:12:35 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/14 01:16:09 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,6 +41,30 @@ void	print_envs(t_env *envs)
 		ft_putchar_fd('\n', STDOUT_FILENO);
 		envs = envs->next;
 	}
+}
+
+char	**generate_environ(t_env *envs)
+{
+	char	**environ;
+	size_t	env_size;
+	size_t	i;
+
+	env_size = get_env_size(envs);
+	environ = (char **)malloc(sizeof(char *) * (env_size + 1));
+	if (!environ)
+		error_exit();
+	i = 0;
+	while (i < env_size)
+	{
+		if (!(environ[i] = ft_strjoin(envs->name, "=")))
+			error_exit();
+		if (!(environ[i] = ft_strjoin(environ[i], envs->value)))
+			error_exit();
+		i++;
+		envs = envs->next;
+	}
+	environ[i] = NULL;
+	return (environ);
 }
 
 void	add_env(t_env **envs, t_env *new_env)

--- a/srcs/utils/env_utils.c
+++ b/srcs/utils/env_utils.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/13 23:38:53 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/14 01:18:45 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/14 15:20:50 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,12 +47,8 @@ t_env	*create_new_env(char *env_str)
 		error_exit();
 	sep = ft_strchr(env_str, '=');
 	if (!sep)
-	{
-		free(env);
-		return (NULL);
-	}
-	*sep = '\0';
-	env->name = ft_strdup(env_str);
+		error_exit();
+	env->name = ft_substr(env_str, 0, sep - env_str);
 	env->value = ft_strdup(sep + 1);
 	if (!env->name || !env->value)
 		error_exit();

--- a/srcs/utils/env_utils.c
+++ b/srcs/utils/env_utils.c
@@ -1,0 +1,48 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   env_utils.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/02/13 23:38:53 by nfukada           #+#    #+#             */
+/*   Updated: 2021/02/14 01:13:06 by nfukada          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "utils.h"
+#include "libft.h"
+
+t_env	*get_last_env(t_env *envs)
+{
+	t_env	*target;
+
+	if (!envs)
+		return (NULL);
+	target = envs;
+	while (target->next)
+		target = target->next;
+	return (target);
+}
+
+t_env	*create_new_env(char *env_str)
+{
+	t_env	*env;
+	char	*sep;
+
+	if (!(env = malloc(sizeof(t_env))))
+		error_exit();
+	sep = ft_strchr(env_str, '=');
+	if (!sep)
+	{
+		free(env);
+		return (NULL);
+	}
+	*sep = '\0';
+	env->name = ft_strdup(env_str);
+	env->value = ft_strdup(sep + 1);
+	if (!env->name || !env->value)
+		error_exit();
+	env->next = NULL;
+	return (env);
+}

--- a/srcs/utils/env_utils.c
+++ b/srcs/utils/env_utils.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/13 23:38:53 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/14 01:13:06 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/14 01:16:45 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,19 @@ t_env	*get_last_env(t_env *envs)
 	while (target->next)
 		target = target->next;
 	return (target);
+}
+
+size_t	get_env_size(t_env *envs)
+{
+	size_t	size;
+
+	size = 0;
+	while (envs)
+	{
+		envs = envs->next;
+		size++;
+	}
+	return (size);
 }
 
 t_env	*create_new_env(char *env_str)

--- a/srcs/utils/env_utils.c
+++ b/srcs/utils/env_utils.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/13 23:38:53 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/14 01:16:45 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/14 01:18:45 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,4 +58,13 @@ t_env	*create_new_env(char *env_str)
 		error_exit();
 	env->next = NULL;
 	return (env);
+}
+
+void	free_env(t_env *env)
+{
+	free(env->name);
+	free(env->value);
+	env->name = NULL;
+	env->value = NULL;
+	free(env);
 }


### PR DESCRIPTION
Fix #2

## やったこと
- 環境変数environから連結リストへ。
- execveするときは、連結リストをenviron形式へ変換するように。

### 各関数
env.c: 外部から呼び出されることを想定した関数

|関数名|説明|
|--|--|
|create_envs_from_environ|environからt_envのリスト作成|
|print_envs|t_envのリストを標準出力に出力|
|generate_environ|t_envのリストからenviron形式の文字列配列作成|
|add_env|指定のt_envを追加|
|del_env|指定nameの環境変数をt_envから削除|

env_utils.c: env.cの関数から呼び出されることを想定した関数

|関数名|説明|
|--|--|
|get_last_env|t_envリストの最後の要素を取得|
|get_env_size|t_envリストのサイズ取得|
|create_new_env|name=valueの文字列からt_env作成|

## 気になっていること
- utils/env_utils.c の命名がいけてないので、env用にディレクトリを切るか迷っています。

## 確認した項目
- norm
- create_envs_from_environ, generate_environ: minishell外で設定した環境変数がminishellに反映されること
  ```bash
  $ echo a.sh
  #!/bin/bash
  echo $A
  $ export A=aaa
  $ ./minishell
  > ./a.sh
  aaa
  ```
- print_envs: mainに追記してbashとのdiffを取って確認。
- add_env, del_env はexport, unsetで確認したいです。
