### PR TITLE
refactor: envsでなくglobal変数のg_envsを使用するように

### DIFF
--- a/includes/exec.h
+++ b/includes/exec.h
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 20:07:01 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/22 17:51:14 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/23 18:05:51 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,7 +42,7 @@ typedef struct			s_command
 	t_redirect			*redirects;
 }						t_command;
 
-void					exec_nodes(t_node *nodes, t_env *envs);
+void					exec_nodes(t_node *nodes);
 
 char					**convert_args(t_command *command);
 

--- a/srcs/exec/exec_command.c
+++ b/srcs/exec/exec_command.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 17:59:52 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/22 18:48:47 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/23 18:06:18 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,11 +16,12 @@
 #include "builtin.h"
 #include "utils.h"
 
-static void	exec_command_node(t_node *node, t_env *envs)
+static void	exec_command_node(t_node *node)
 {
-	pid_t	pid;
-	int		status;
-	char	**args;
+	extern t_env	*g_envs;
+	pid_t			pid;
+	int				status;
+	char			**args;
 
 	args = convert_args(node->command);
 	if (args[0] == NULL)
@@ -34,7 +35,7 @@ static void	exec_command_node(t_node *node, t_env *envs)
 		error_exit();
 	if (pid == 0)
 	{
-		if (execve(args[0], args, generate_environ(envs)) < 0)
+		if (execve(args[0], args, generate_environ(g_envs)) < 0)
 			error_exit();
 	}
 	else
@@ -44,15 +45,15 @@ static void	exec_command_node(t_node *node, t_env *envs)
 	}
 }
 
-static void	exec_command(t_node *nodes, t_env *envs)
+static void	exec_command(t_node *nodes)
 {
 	if (nodes->type == NODE_COMMAND)
 	{
-		exec_command_node(nodes, envs);
+		exec_command_node(nodes);
 	}
 }
 
-static void	exec_pipeline(t_node *nodes, t_env *envs)
+static void	exec_pipeline(t_node *nodes)
 {
 	if (!nodes)
 	{
@@ -60,16 +61,16 @@ static void	exec_pipeline(t_node *nodes, t_env *envs)
 	}
 	if (nodes->type == NODE_PIPE)
 	{
-		exec_pipeline(nodes->left, envs);
-		exec_pipeline(nodes->right, envs);
+		exec_pipeline(nodes->left);
+		exec_pipeline(nodes->right);
 	}
 	else
 	{
-		exec_command(nodes, envs);
+		exec_command(nodes);
 	}
 }
 
-void		exec_nodes(t_node *nodes, t_env *envs)
+void		exec_nodes(t_node *nodes)
 {
 	if (!nodes)
 	{
@@ -77,11 +78,11 @@ void		exec_nodes(t_node *nodes, t_env *envs)
 	}
 	if (nodes->type == NODE_SEMICOLON)
 	{
-		exec_nodes(nodes->left, envs);
-		exec_nodes(nodes->right, envs);
+		exec_nodes(nodes->left);
+		exec_nodes(nodes->right);
 	}
 	else
 	{
-		exec_pipeline(nodes, envs);
+		exec_pipeline(nodes);
 	}
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/10 18:50:22 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/22 18:54:15 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/23 18:09:03 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,8 @@
 #include "lexer.h"
 #include "parser.h"
 #include "exec.h"
+
+t_env	*g_envs;
 
 void	free_array(char **array)
 {
@@ -31,7 +33,7 @@ void	free_array(char **array)
 	array = NULL;
 }
 
-void	loop_shell(t_env *envs)
+void	loop_shell(void)
 {
 	int		status;
 	char	*line;
@@ -50,7 +52,7 @@ void	loop_shell(t_env *envs)
 		if (parse_complete_command(&nodes, &tokens) == FALSE)
 			print_unexpected_token_error(tokens);
 		else
-			exec_nodes(nodes, envs);
+			exec_nodes(nodes);
 		free(line);
 		del_token_list(&start_token);
 		del_node_list(nodes);
@@ -59,10 +61,8 @@ void	loop_shell(t_env *envs)
 
 int		main(int argc, char *argv[])
 {
-	t_env	*envs;
-
 	(void)argc;
 	(void)argv;
-	envs = create_envs_from_environ();
-	loop_shell(envs);
+	g_envs = create_envs_from_environ();
+	loop_shell();
 }


### PR DESCRIPTION
Fix #25

## やったこと
main.c: g_envsを設定。
exec.c: exec_系関数の引数からenvを削除。

g_envsを設定したことにより、コンパイルが通るようになりました:tada: