### PR TITLE
fix: DEBUGフラグが立ってる時ast.dotを出力しないように

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ Temporary Items
 # End of https://www.toptal.com/developers/gitignore/api/c,linux,macos
 
 minishell
+minishell_debug
 *.bak
 .vscode/*
 *debug_.c

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2021/02/10 18:36:52 by nfukada           #+#    #+#              #
-#    Updated: 2021/02/24 17:07:52 by nfukada          ###   ########.fr        #
+#    Updated: 2021/02/24 17:09:22 by nfukada          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -60,9 +60,9 @@ debug	: clean
 
 norm	:
 ifeq ($(shell which norminette),)
-		~/.norminette/norminette.rb $(SRCS) $(INC_DIR)
+	~/.norminette/norminette.rb $(SRCS) $(INC_DIR)
 else
-		norminette $(SRCS) $(INC_DIR)
+	norminette $(SRCS) $(INC_DIR)
 endif
 
 srcs	:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2021/02/10 18:36:52 by nfukada           #+#    #+#              #
-#    Updated: 2021/02/22 17:18:22 by nfukada          ###   ########.fr        #
+#    Updated: 2021/02/24 14:45:38 by nfukada          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -22,10 +22,12 @@ SRCS		:= srcs/lexer/lexer_general_state.c srcs/lexer/lexer.c srcs/lexer/lexer_qu
 OBJS		:= $(SRCS:%.c=%.o)
 LIBS		:= -lft -L$(LIBFT_DIR)
 
-CC			:= gcc
-CFLAGS		:= -Wall -Werror -Wextra $(INC) -g -fsanitize=address
+DEBUG		:= FALSE
 
-.PHONY: all clean fclean re bonus norm srcs
+CC			:= gcc
+CFLAGS		:= -Wall -Werror -Wextra $(INC) -g -fsanitize=address -D DEBUG=$(DEBUG)
+
+.PHONY: all clean fclean re bonus debug norm srcs
 
 all		: $(NAME)
 
@@ -46,6 +48,9 @@ fclean	: clean
 	rm -f $(NAME)
 
 re		: fclean all
+
+debug	:
+	$(MAKE) DEBUG=TRUE
 
 norm	:
 ifeq ($(shell which norminette),)

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,16 @@
 #    By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2021/02/10 18:36:52 by nfukada           #+#    #+#              #
-#    Updated: 2021/02/24 14:45:38 by nfukada          ###   ########.fr        #
+#    Updated: 2021/02/24 17:07:52 by nfukada          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
 NAME		:= minishell
+NAME_DEBUG	:= minishell_debug
+
+ifdef DEBUG
+NAME		:= $(NAME_DEBUG)
+endif
 
 SRC_DIR		:= srcs
 INC_DIR		:= includes
@@ -45,12 +50,13 @@ clean	:
 
 fclean	: clean
 	$(MAKE) fclean -C $(LIBFT_DIR)
-	rm -f $(NAME)
+	rm -f $(NAME) $(NAME_DEBUG)
 
 re		: fclean all
 
-debug	:
+debug	: clean
 	$(MAKE) DEBUG=TRUE
+	$(MAKE) clean
 
 norm	:
 ifeq ($(shell which norminette),)

--- a/includes/const.h
+++ b/includes/const.h
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/10 19:46:48 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/12 21:06:13 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/24 14:54:13 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,5 +14,9 @@
 # define CONST_H
 
 # define SHELL_PROMPT	"\e[32mminishell > \e[0m"
+
+# ifndef DEBUG
+#  define DEBUG			FALSE
+# endif
 
 #endif

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -6,13 +6,14 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/17 01:11:20 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/22 01:00:40 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/24 14:51:19 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "token.h"
 #include "parser.h"
 #include "utils.h"
+#include "const.h"
 
 static t_bool	parse_io_redirect(t_token **tokens, t_node *command_node)
 {
@@ -117,6 +118,7 @@ t_bool			parse_complete_command(t_node **nodes, t_token **tokens)
 	}
 	if (*tokens)
 		return (FALSE);
-	print_nodes(*nodes);
+	if (DEBUG)
+		print_nodes(*nodes);
 	return (TRUE);
 }


### PR DESCRIPTION
Fix #29

## やったこと
DEBUGマクロを追加しました。TRUEかFALSEの値を取ります。
DEBUGの値に応じてast.dot出力設定を切り替えるようにしています。

DEBUGは、デフォルトはFALSEです。`make debug` とすると、TRUEになります。

今後、lexerのdebug出力にも使えるかなと思っています。