### PR TITLE
syntax error時にstatus=258を設定するように

### DIFF
--- a/includes/const.h
+++ b/includes/const.h
@@ -6,14 +6,16 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/10 19:46:48 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/24 14:54:13 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/27 12:34:40 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef CONST_H
 # define CONST_H
 
-# define SHELL_PROMPT	"\e[32mminishell > \e[0m"
+# define SHELL_PROMPT			"\e[32mminishell > \e[0m"
+
+# define STATUS_SYNTAX_ERROR	258
 
 # ifndef DEBUG
 #  define DEBUG			FALSE

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 20:13:16 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/21 14:53:27 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/27 12:39:41 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ typedef struct	s_env
 }				t_env;
 
 void			error_exit(void);
-void			print_unexpected_token_error(t_token *token);
+void			print_syntax_error(t_token *token);
 
 t_env			*create_envs_from_environ(void);
 void			print_envs(t_env *envs);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/10 18:50:22 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/27 12:33:18 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/27 12:39:23 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,7 @@ void	run_commandline(char *line)
 	tokens = tokenise(line, FALSE);
 	start_token = tokens;
 	if (parse_complete_command(&nodes, &tokens) == FALSE)
-		print_unexpected_token_error(tokens);
+		print_syntax_error(tokens);
 	else
 		exec_nodes(nodes);
 	del_token_list(&start_token);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/10 18:50:22 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/24 10:28:54 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/27 12:33:18 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,7 @@
 #include "exec.h"
 
 t_env	*g_envs;
+int		g_status;
 
 void	run_commandline(char *line)
 {
@@ -65,4 +66,5 @@ int		main(int argc, char *argv[])
 	{
 		loop_shell();
 	}
+	return (g_status);
 }

--- a/srcs/utils/error.c
+++ b/srcs/utils/error.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 20:12:22 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/27 12:35:06 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/27 12:39:54 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@ void	error_exit(void)
 	exit(1);
 }
 
-void	print_unexpected_token_error(t_token *token)
+void	print_syntax_error(t_token *token)
 {
 	extern int	g_status;
 

--- a/srcs/utils/error.c
+++ b/srcs/utils/error.c
@@ -6,12 +6,13 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 20:12:22 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/21 00:34:12 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/02/27 12:35:06 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <errno.h>
 #include <string.h>
+#include "const.h"
 #include "libft.h"
 #include "token.h"
 
@@ -24,6 +25,8 @@ void	error_exit(void)
 
 void	print_unexpected_token_error(t_token *token)
 {
+	extern int	g_status;
+
 	ft_putstr_fd(
 		"minishell: syntax error near unexpected token `", STDERR_FILENO);
 	if (token)
@@ -35,4 +38,5 @@ void	print_unexpected_token_error(t_token *token)
 		ft_putstr_fd("newline", STDERR_FILENO);
 	}
 	ft_putendl_fd("'", STDERR_FILENO);
+	g_status = STATUS_SYNTAX_ERROR;
 }


### PR DESCRIPTION
Fix #34

## やったこと
### テストのエラー修正
グローバル変数g_status追加。
syntax error時にg_statusを258にセットするように。
→ テストが通るようになりました。

### リファクタリング（関数名変更）
print_unexpected_token_error を print_syntax_error にしました。
print_unexpected_token_error は長すぎるので。