### PR TITLE
トークン関連のバグ修正

### DIFF
--- a/includes/lexer.h
+++ b/includes/lexer.h
@@ -6,7 +6,7 @@
 /*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 16:44:34 by totaisei          #+#    #+#             */
-/*   Updated: 2021/02/22 07:53:09 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/01 09:55:12 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,7 @@ typedef struct	s_tokeniser{
 	size_t			tok_i;
 	size_t			str_len;
 	t_bool			esc_flag;
+	t_bool			is_quoted;
 	t_token			*token;
 	t_token			*tokens_start;
 	t_token_state	state;

--- a/includes/token.h
+++ b/includes/token.h
@@ -6,7 +6,7 @@
 /*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/18 15:25:56 by totaisei          #+#    #+#             */
-/*   Updated: 2021/02/22 13:11:24 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/01 10:23:34 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,7 @@ typedef enum	e_tokentype{
 	CHAR_ESCAPE = '\\',
 	CHAR_GREATER = '>',
 	CHAR_LESSER = '<',
+	CHAR_TAB = '\t',
 	CHAR_NULL = 0,
 	D_SEMICOLON = -4,
 	D_GREATER = -3,

--- a/srcs/lexer/lexer.c
+++ b/srcs/lexer/lexer.c
@@ -6,7 +6,7 @@
 /*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/18 20:01:44 by totaisei          #+#    #+#             */
-/*   Updated: 2021/02/20 10:26:35 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/01 10:18:18 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@ void	close_token_list(t_tokeniser *toker)
 		del_token_list(&(toker->tokens_start));
 		return ;
 	}
-	if (toker->tok_i == 0)
+	if (toker->tok_i == 0 && toker->is_quoted == FALSE)
 	{
 		if (toker->tokens_start == toker->token)
 			del_token_list(&toker->tokens_start);
@@ -48,6 +48,7 @@ void	tokeniser_init(t_tokeniser *toker, char *str, t_bool esc_flag)
 	toker->tok_i = 0;
 	toker->str_len = len;
 	toker->esc_flag = esc_flag;
+	toker->is_quoted = FALSE;
 }
 
 t_token	*tokenise(char *str, t_bool esc_flag)

--- a/srcs/lexer/lexer_general_state.c
+++ b/srcs/lexer/lexer_general_state.c
@@ -6,7 +6,7 @@
 /*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/19 18:59:13 by totaisei          #+#    #+#             */
-/*   Updated: 2021/03/01 10:17:16 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/01 10:28:12 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,7 +56,7 @@ void	general_sep_process(t_tokeniser *toker, t_token_type type, char *str)
 	if (is_io_number_token(toker, type))
 		toker->token->type = IO_NUMBER;
 	tokeniser_add_new_token(toker);
-	if (type != CHAR_WHITESPACE)
+	if (type != CHAR_WHITESPACE && type != CHAR_TAB)
 	{
 		toker->token->data[toker->tok_i++] = str[toker->str_i];
 		if (str[toker->str_i + 1] == str[toker->str_i])

--- a/srcs/lexer/lexer_general_state.c
+++ b/srcs/lexer/lexer_general_state.c
@@ -6,7 +6,7 @@
 /*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/19 18:59:13 by totaisei          #+#    #+#             */
-/*   Updated: 2021/02/22 08:07:34 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/01 10:17:16 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@ void	tokeniser_add_new_token(t_tokeniser *toker)
 {
 	t_token *tmp_token;
 
-	if (toker->tok_i > 0)
+	if (toker->tok_i > 0 || (toker->is_quoted))
 	{
 		toker->token->data[toker->tok_i] = '\0';
 		tmp_token =
@@ -25,6 +25,7 @@ void	tokeniser_add_new_token(t_tokeniser *toker)
 		toker->token->next = tmp_token;
 		toker->token = tmp_token;
 		toker->tok_i = 0;
+		toker->is_quoted = FALSE;
 	}
 }
 
@@ -103,19 +104,19 @@ void	general_state(t_tokeniser *toker, t_token_type type, char *str)
 		if (type == CHAR_QOUTE)
 		{
 			toker->state = STATE_IN_QUOTE;
+			toker->is_quoted = TRUE;
 			if (toker->esc_flag)
 				toker->tok_i -= 1;
 		}
 		else if (type == CHAR_DQUOTE)
 		{
 			toker->state = STATE_IN_DQUOTE;
+			toker->is_quoted = TRUE;
 			if (toker->esc_flag)
 				toker->tok_i -= 1;
 		}
 		else
-		{
 			toker->state = STATE_GENERAL;
-		}
 		toker->token->type = TOKEN;
 	}
 	else

--- a/srcs/utils/token.c
+++ b/srcs/utils/token.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   token.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/18 18:05:44 by totaisei          #+#    #+#             */
-/*   Updated: 2021/02/27 23:28:40 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/01 10:31:35 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,9 +51,9 @@ t_token_type	judge_token_type(char c)
 {
 	int			command_count;
 	const char	commands[] = {
-		'|', '\'', '\"', ' ', ';', '\\', '>', '<', '\0'};
+		'|', '\'', '\"', ' ', ';', '\\', '>', '<', '\t', '\0'};
 
-	command_count = 9;
+	command_count = 10;
 	while (command_count--)
 	{
 		if (commands[command_count] == c)

--- a/tests/cases/echo_test.txt
+++ b/tests/cases/echo_test.txt
@@ -1,10 +1,10 @@
 echo
 echo a
 echo hello world
-echo -n 
+echo -n
 echo -n a
 echo -n hello world
-echo -nnnnnnnn 
+echo -nnnnnnnn
 echo -nnnnnnnn a
 echo -nnnnnnnn hello world
 echo -nnnnnnnn -nnnnnnnn
@@ -31,3 +31,6 @@ echo '$PATH'
 echo \$PATH
 echo "\$PATH"
 echo '\$PATH'
+echo a "" b "" c
+echo a "$NO_SUCH_ENV" b $NO_SUCH_ENV c
+echo		hello


### PR DESCRIPTION
fix #48
fix #47


### 確認したこと

```
~/42_minishell>bash
%F{green}%~>%fecho a "" b "" c
a  b  c
%F{green}%~>%fecho a '' b '' c
a  b  c
%F{green}%~>%fecho a "$B" c $C d
a  c d
%F{green}%~>%f./minishell 
minishell > echo a "" b "" c
a  b  c
minishell >  echo a '' b '' c
a  b  c
minishell >  echo a "$B" c $C d
a  c d
```
`echo \t hello`
`echo "\thello\t"`
`echo \t \t hello`
