### PR TITLE
シグナルハンドラ実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ LIBFT_DIR	:= libft
 LIBFT		:= $(LIBFT_DIR)/libft.a
 INC			:= -I$(INC_DIR) -I$(LIBFT_DIR)
 
-SRCS		:= srcs/lexer/lexer_general_state.c srcs/lexer/lexer.c srcs/lexer/lexer_quote_state.c srcs/utils/shell_init.c srcs/utils/shlvl_init.c srcs/utils/token_utils.c srcs/utils/token.c srcs/utils/env_utils_get.c srcs/utils/env.c srcs/utils/error.c srcs/utils/env_utils.c srcs/parser/parser_utils.c srcs/parser/redirect.c srcs/parser/print_node_label.c srcs/parser/parser.c srcs/parser/node.c srcs/parser/print_node.c srcs/expander/expander.c srcs/expander/expand_tokens.c srcs/expander/expand_var.c srcs/main.c srcs/exec/exec_command.c srcs/exec/exec.c srcs/exec/build_path_stat.c srcs/exec/command.c srcs/exec/build_path.c srcs/exec/exec_pipe.c srcs/exec/exec_redirect.c srcs/exec/build_path_utils.c srcs/builtin/mini_echo.c srcs/builtin/builtin.c srcs/builtin/mini_exit.c
+SRCS		:= srcs/lexer/lexer_general_state.c srcs/lexer/lexer.c srcs/lexer/lexer_quote_state.c srcs/utils/shell_init.c srcs/utils/shlvl_init.c srcs/utils/token_utils.c srcs/utils/token.c srcs/utils/env_utils_get.c srcs/utils/env.c srcs/utils/error.c srcs/utils/signal.c srcs/utils/env_utils.c srcs/parser/parser_utils.c srcs/parser/redirect.c srcs/parser/print_node_label.c srcs/parser/parser.c srcs/parser/node.c srcs/parser/print_node.c srcs/expander/expander.c srcs/expander/expand_tokens.c srcs/expander/expand_var.c srcs/main.c srcs/exec/exec_command.c srcs/exec/exec.c srcs/exec/build_path_stat.c srcs/exec/command.c srcs/exec/build_path.c srcs/exec/exec_pipe.c srcs/exec/exec_redirect.c srcs/exec/build_path_utils.c srcs/builtin/mini_echo.c srcs/builtin/builtin.c srcs/builtin/mini_exit.c 
 OBJS		:= $(SRCS:%.c=%.o)
 LIBS		:= -lft -L$(LIBFT_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2021/02/10 18:36:52 by nfukada           #+#    #+#              #
-#    Updated: 2021/03/03 21:56:21 by nfukada          ###   ########.fr        #
+#    Updated: 2021/03/05 18:03:45 by nfukada          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -23,14 +23,14 @@ LIBFT_DIR	:= libft
 LIBFT		:= $(LIBFT_DIR)/libft.a
 INC			:= -I$(INC_DIR) -I$(LIBFT_DIR)
 
-SRCS		:= srcs/lexer/lexer_general_state.c srcs/lexer/lexer.c srcs/lexer/lexer_quote_state.c srcs/utils/shell_init.c srcs/utils/shlvl_init.c srcs/utils/token_utils.c srcs/utils/token.c srcs/utils/env_utils_get.c srcs/utils/env.c srcs/utils/error.c srcs/utils/signal.c srcs/utils/env_utils.c srcs/parser/parser_utils.c srcs/parser/redirect.c srcs/parser/print_node_label.c srcs/parser/parser.c srcs/parser/node.c srcs/parser/print_node.c srcs/expander/expander.c srcs/expander/expand_tokens.c srcs/expander/expand_var.c srcs/main.c srcs/exec/exec_command.c srcs/exec/exec.c srcs/exec/build_path_stat.c srcs/exec/command.c srcs/exec/build_path.c srcs/exec/exec_pipe.c srcs/exec/exec_redirect.c srcs/exec/build_path_utils.c srcs/builtin/mini_echo.c srcs/builtin/builtin.c srcs/builtin/mini_exit.c 
+SRCS		:= srcs/lexer/lexer_general_state.c srcs/lexer/lexer.c srcs/lexer/lexer_quote_state.c srcs/utils/shell_init.c srcs/utils/shlvl_init.c srcs/utils/token_utils.c srcs/utils/token.c srcs/utils/env_utils_get.c srcs/utils/env.c srcs/utils/error.c srcs/utils/error_print.c srcs/utils/signal.c srcs/utils/env_utils.c srcs/parser/parser_utils.c srcs/parser/redirect.c srcs/parser/print_node_label.c srcs/parser/parser.c srcs/parser/node.c srcs/parser/print_node.c srcs/expander/expander.c srcs/expander/expand_tokens.c srcs/expander/expand_var.c srcs/main.c srcs/exec/exec_command.c srcs/exec/exec.c srcs/exec/build_path_stat.c srcs/exec/command.c srcs/exec/build_path.c srcs/exec/exec_pipe.c srcs/exec/exec_redirect.c srcs/exec/build_path_utils.c srcs/builtin/mini_echo.c srcs/builtin/builtin.c srcs/builtin/mini_exit.c 
 OBJS		:= $(SRCS:%.c=%.o)
 LIBS		:= -lft -L$(LIBFT_DIR)
 
 DEBUG		:= FALSE
 
 CC			:= gcc
-CFLAGS		:= -Wall -Werror -Wextra $(INC) -g -fsanitize=address -D DEBUG=$(DEBUG)
+CFLAGS		:= -Wall -Werror -Wextra $(INC) -D DEBUG=$(DEBUG)
 
 .PHONY: all clean fclean re bonus debug norm srcs
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2021/02/10 18:36:52 by nfukada           #+#    #+#              #
-#    Updated: 2021/03/05 18:03:45 by nfukada          ###   ########.fr        #
+#    Updated: 2021/03/05 21:07:48 by nfukada          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -23,14 +23,12 @@ LIBFT_DIR	:= libft
 LIBFT		:= $(LIBFT_DIR)/libft.a
 INC			:= -I$(INC_DIR) -I$(LIBFT_DIR)
 
-SRCS		:= srcs/lexer/lexer_general_state.c srcs/lexer/lexer.c srcs/lexer/lexer_quote_state.c srcs/utils/shell_init.c srcs/utils/shlvl_init.c srcs/utils/token_utils.c srcs/utils/token.c srcs/utils/env_utils_get.c srcs/utils/env.c srcs/utils/error.c srcs/utils/error_print.c srcs/utils/signal.c srcs/utils/env_utils.c srcs/parser/parser_utils.c srcs/parser/redirect.c srcs/parser/print_node_label.c srcs/parser/parser.c srcs/parser/node.c srcs/parser/print_node.c srcs/expander/expander.c srcs/expander/expand_tokens.c srcs/expander/expand_var.c srcs/main.c srcs/exec/exec_command.c srcs/exec/exec.c srcs/exec/build_path_stat.c srcs/exec/command.c srcs/exec/build_path.c srcs/exec/exec_pipe.c srcs/exec/exec_redirect.c srcs/exec/build_path_utils.c srcs/builtin/mini_echo.c srcs/builtin/builtin.c srcs/builtin/mini_exit.c 
+SRCS		:= srcs/lexer/lexer_general_state.c srcs/lexer/lexer.c srcs/lexer/lexer_quote_state.c srcs/utils/shell_init.c srcs/utils/shlvl_init.c srcs/utils/token_utils.c srcs/utils/token.c srcs/utils/env_utils_get.c srcs/utils/env.c srcs/utils/error.c srcs/utils/error_print.c srcs/utils/signal.c srcs/utils/env_utils.c srcs/parser/parser_utils.c srcs/parser/redirect.c srcs/parser/print_node_label.c srcs/parser/parser.c srcs/parser/node.c srcs/parser/print_node.c srcs/expander/expander.c srcs/expander/expand_tokens.c srcs/expander/expand_var.c srcs/main.c srcs/exec/exec_command.c srcs/exec/exec.c srcs/exec/build_path_stat.c srcs/exec/command.c srcs/exec/build_path.c srcs/exec/exec_pipe.c srcs/exec/exec_redirect.c srcs/exec/build_path_utils.c srcs/builtin/mini_echo.c srcs/builtin/builtin.c srcs/builtin/mini_exit.c
 OBJS		:= $(SRCS:%.c=%.o)
 LIBS		:= -lft -L$(LIBFT_DIR)
 
-DEBUG		:= FALSE
-
 CC			:= gcc
-CFLAGS		:= -Wall -Werror -Wextra $(INC) -D DEBUG=$(DEBUG)
+CFLAGS		:= -Wall -Werror -Wextra $(INC)
 
 .PHONY: all clean fclean re bonus debug norm srcs
 
@@ -55,7 +53,7 @@ fclean	: clean
 re		: fclean all
 
 debug	: clean
-	$(MAKE) DEBUG=TRUE
+	$(MAKE) CFLAGS="$(CFLAGS) -D DEBUG=TRUE -g -fsanitize=address" DEBUG=TRUE
 	$(MAKE) clean
 
 norm	:

--- a/includes/const.h
+++ b/includes/const.h
@@ -14,6 +14,8 @@
 # define CONST_H
 
 # define SHELL_PROMPT			"\e[32mminishell > \e[0m"
+# define BACK_CURSOR			"\033[2D"
+# define CLEAR_FROM_CURSOR		"\033[0K"
 
 # define STATUS_SYNTAX_ERROR		258
 # define STATUS_TOKEN_ERROR			2

--- a/includes/exec.h
+++ b/includes/exec.h
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 20:07:01 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/03 21:49:06 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/05 20:40:26 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,6 +80,7 @@ t_bool					dup_redirects(t_command *command, t_bool is_parent);
 void					cleanup_redirects(t_command *command);
 
 t_bool					convert_tokens(t_command *command, char ***args);
+void					wait_commands(t_command *command);
 
 char					*build_full_path(char *path, const char *cmd);
 char					*build_cmd_path(const char *cmd);

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 20:13:16 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/04 15:50:58 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/05 00:42:45 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,5 +47,8 @@ t_env			*get_env(const char *name);
 void			minishell_init(void);
 void			shlvl_init(void);
 t_bool			is_digit_str(char *str);
+
+void			set_signal_handler(void (*func)(int));
+void			handle_signal(int signal);
 
 #endif

--- a/srcs/builtin/mini_exit.c
+++ b/srcs/builtin/mini_exit.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/04 14:59:01 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/04 17:15:05 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/05 20:55:41 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,22 @@
 #include "libft.h"
 #include "utils.h"
 
-int		exec_exit(char **args)
+static t_bool	has_error(char **args, int index)
+{
+	if (errno || is_digit_str(args[index]) == FALSE)
+	{
+		print_numeric_argument_error(args[index]);
+		exit(255);
+	}
+	if (args[index + 1])
+	{
+		print_error("too many arguments", "exit");
+		return (TRUE);
+	}
+	return (FALSE);
+}
+
+int				exec_exit(char **args)
 {
 	extern int		g_status;
 	extern t_bool	g_interactive;
@@ -30,16 +45,8 @@ int		exec_exit(char **args)
 		exit(g_status);
 	errno = 0;
 	status = ft_atoi(args[i]);
-	if (errno || is_digit_str(args[i]) == FALSE)
-	{
-		print_numeric_argument_error(args[i]);
-		exit(255);
-	}
-	if (args[i + 1])
-	{
-		print_error("too many arguments", "exit");
+	if (has_error(args, i) == TRUE)
 		return (EXIT_FAILURE);
-	}
 	exit(status);
 	return (EXIT_FAILURE);
 }

--- a/srcs/exec/command.c
+++ b/srcs/exec/command.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/22 17:08:55 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/02 20:45:36 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/05 20:39:43 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,4 +51,48 @@ t_bool		convert_tokens(t_command *command, char ***args)
 		return (FALSE);
 	}
 	return (TRUE);
+}
+
+static void	handle_command_status(int status, t_bool catch_sigint)
+{
+	extern int	g_status;
+	int			signal;
+
+	if (WIFEXITED(status))
+		g_status = WEXITSTATUS(status);
+	else if (WIFSIGNALED(status))
+	{
+		signal = WTERMSIG(status);
+		if (signal == SIGQUIT)
+			ft_putendl_fd("Quit: 3", STDERR_FILENO);
+		g_status = signal + 128;
+	}
+	if (catch_sigint)
+		ft_putendl_fd("", STDERR_FILENO);
+}
+
+void		wait_commands(t_command *command)
+{
+	extern int	g_status;
+	int			status;
+	t_bool		has_child;
+	t_bool		catch_sigint;
+
+	has_child = FALSE;
+	catch_sigint = FALSE;
+	while (command)
+	{
+		if (command->pid != NO_PID)
+		{
+			if (waitpid(command->pid, &status, 0) < 0)
+				error_exit(NULL);
+			if (WIFSIGNALED(status) && WTERMSIG(status) == SIGINT)
+				catch_sigint = TRUE;
+			has_child = TRUE;
+		}
+		command = command->next;
+	}
+	if (has_child == FALSE)
+		return ;
+	handle_command_status(status, catch_sigint);
 }

--- a/srcs/exec/command.c
+++ b/srcs/exec/command.c
@@ -6,10 +6,12 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/22 17:08:55 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/05 20:39:43 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/06 22:01:38 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <signal.h>
+#include <sys/wait.h>
 #include "exec.h"
 #include "expander.h"
 

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 17:59:52 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/05 16:20:53 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/05 20:36:29 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,43 +14,6 @@
 #include <sys/wait.h>
 #include "parser.h"
 #include "utils.h"
-
-static void		wait_commands(t_command *command)
-{
-	extern int	g_status;
-	int			status;
-	t_bool		has_child;
-	t_bool		catch_sigint;
-	int			signal;
-
-	has_child = FALSE;
-	catch_sigint = FALSE;
-	while (command)
-	{
-		if (command->pid != NO_PID)
-		{
-			if (waitpid(command->pid, &status, 0) < 0)
-				error_exit(NULL);
-			if (WIFSIGNALED(status) && WTERMSIG(status) == SIGINT)
-				catch_sigint = TRUE;
-			has_child = TRUE;
-		}
-		command = command->next;
-	}
-	if (has_child == FALSE)
-		return ;
-	if (WIFEXITED(status))
-		g_status = WEXITSTATUS(status);
-	else if (WIFSIGNALED(status))
-	{
-		signal = WTERMSIG(status);
-		if (signal == SIGQUIT)
-			ft_putendl_fd("Quit: 3", STDERR_FILENO);
-		g_status = signal + 128;
-	}
-	if (catch_sigint)
-		ft_putendl_fd("", STDERR_FILENO);
-}
 
 static void		exec_pipeline(t_node *nodes)
 {

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 17:59:52 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/03 14:27:19 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/05 16:20:53 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,20 +20,36 @@ static void		wait_commands(t_command *command)
 	extern int	g_status;
 	int			status;
 	t_bool		has_child;
+	t_bool		catch_sigint;
+	int			signal;
 
 	has_child = FALSE;
+	catch_sigint = FALSE;
 	while (command)
 	{
 		if (command->pid != NO_PID)
 		{
 			if (waitpid(command->pid, &status, 0) < 0)
 				error_exit(NULL);
+			if (WIFSIGNALED(status) && WTERMSIG(status) == SIGINT)
+				catch_sigint = TRUE;
 			has_child = TRUE;
 		}
 		command = command->next;
 	}
-	if (has_child == TRUE && WIFEXITED(status))
+	if (has_child == FALSE)
+		return ;
+	if (WIFEXITED(status))
 		g_status = WEXITSTATUS(status);
+	else if (WIFSIGNALED(status))
+	{
+		signal = WTERMSIG(status);
+		if (signal == SIGQUIT)
+			ft_putendl_fd("Quit: 3", STDERR_FILENO);
+		g_status = signal + 128;
+	}
+	if (catch_sigint)
+		ft_putendl_fd("", STDERR_FILENO);
 }
 
 static void		exec_pipeline(t_node *nodes)

--- a/srcs/exec/exec_command.c
+++ b/srcs/exec/exec_command.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/27 20:16:45 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/03 22:15:15 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/05 14:08:07 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,6 +58,7 @@ static void		exec_command_child(
 		error_exit(NULL);
 	if (pid == 0)
 	{
+		set_signal_handler(SIG_DFL);
 		if (setup_redirects(command) == FALSE)
 			exit(EXIT_FAILURE);
 		if (args[0] == NULL)
@@ -70,6 +71,7 @@ static void		exec_command_child(
 		else
 			exec_binary(args);
 	}
+	set_signal_handler(SIG_IGN);
 	cleanup_pipe(state, old_pipe, new_pipe);
 	command->pid = pid;
 }

--- a/srcs/exec/exec_command.c
+++ b/srcs/exec/exec_command.c
@@ -6,12 +6,13 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/27 20:16:45 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/05 14:08:07 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/06 22:02:01 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <errno.h>
 #include <string.h>
+#include <signal.h>
 #include "const.h"
 #include "builtin.h"
 #include "exec.h"

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/10 18:50:22 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/04 15:36:18 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/05 19:46:29 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,6 +46,7 @@ void	loop_shell(void)
 	gnl_result = 1;
 	while (TRUE)
 	{
+		set_signal_handler(handle_signal);
 		if (gnl_result)
 			ft_putstr_fd(SHELL_PROMPT, STDERR_FILENO);
 		if ((gnl_result = ft_get_next_line(STDIN_FILENO, &line)) < 0)

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -50,6 +50,11 @@ void	loop_shell(void)
 			ft_putstr_fd(SHELL_PROMPT, STDERR_FILENO);
 		if ((gnl_result = ft_get_next_line(STDIN_FILENO, &line)) < 0)
 			error_exit(NULL);
+		if (gnl_result == 0 && line[0] == '\0')
+		{
+			ft_putendl_fd("exit", STDERR_FILENO);
+			exit(g_status);
+		}
 		run_commandline(line);
 		free(line);
 	}

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/10 18:50:22 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/05 19:46:29 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/05 21:35:07 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,26 +38,37 @@ void	run_commandline(char *line)
 	del_node_list(nodes);
 }
 
-void	loop_shell(void)
+void	process_input(int *gnl_result)
 {
 	char	*line;
+
+	if (*gnl_result)
+		ft_putstr_fd(SHELL_PROMPT, STDERR_FILENO);
+	if ((*gnl_result = ft_get_next_line(STDIN_FILENO, &line)) < 0)
+		error_exit(NULL);
+	if (*gnl_result == 0)
+	{
+		if (line[0] == '\0')
+		{
+			ft_putendl_fd("exit", STDERR_FILENO);
+			exit(g_status);
+		}
+		ft_putstr_fd(CLEAR_FROM_CURSOR, STDERR_FILENO);
+	}
+	if (*gnl_result)
+		run_commandline(line);
+	free(line);
+}
+
+void	loop_shell(void)
+{
 	int		gnl_result;
 
 	gnl_result = 1;
 	while (TRUE)
 	{
 		set_signal_handler(handle_signal);
-		if (gnl_result)
-			ft_putstr_fd(SHELL_PROMPT, STDERR_FILENO);
-		if ((gnl_result = ft_get_next_line(STDIN_FILENO, &line)) < 0)
-			error_exit(NULL);
-		if (gnl_result == 0 && line[0] == '\0')
-		{
-			ft_putendl_fd("exit", STDERR_FILENO);
-			exit(g_status);
-		}
-		run_commandline(line);
-		free(line);
+		process_input(&gnl_result);
 	}
 }
 

--- a/srcs/utils/error.c
+++ b/srcs/utils/error.c
@@ -6,15 +6,13 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 20:12:22 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/04 15:46:53 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/05 20:29:13 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <errno.h>
 #include <string.h>
-#include "const.h"
 #include "libft.h"
-#include "token.h"
 
 void	print_error(char *message, char *command)
 {
@@ -31,57 +29,4 @@ void	error_exit(char *command)
 {
 	print_error(strerror(errno), command);
 	exit(EXIT_FAILURE);
-}
-
-void	print_syntax_error(t_token *token)
-{
-	extern int	g_status;
-
-	ft_putstr_fd(
-		"minishell: syntax error near unexpected token `", STDERR_FILENO);
-	if (token)
-	{
-		ft_putstr_fd(token->data, STDERR_FILENO);
-	}
-	else
-	{
-		ft_putstr_fd("newline", STDERR_FILENO);
-	}
-	ft_putendl_fd("'", STDERR_FILENO);
-	g_status = STATUS_SYNTAX_ERROR;
-}
-
-void	print_token_error(t_token_state state)
-{
-	extern int	g_status;
-
-	if (state == STATE_IN_DQUOTE)
-		print_error("unexpected EOF while looking for matching `\"'", NULL);
-	if (state == STATE_IN_QUOTE)
-		print_error("unexpected EOF while looking for matching `''", NULL);
-	g_status = STATUS_TOKEN_ERROR;
-}
-
-void	print_bad_fd_error(int fd)
-{
-	char	*fd_str;
-
-	if (fd < 0)
-	{
-		print_error(strerror(errno), "file descriptor out of range");
-	}
-	else
-	{
-		if (!(fd_str = ft_itoa(fd)))
-			error_exit(NULL);
-		print_error(strerror(errno), fd_str);
-		free(fd_str);
-	}
-}
-
-void	print_numeric_argument_error(char *arg)
-{
-	ft_putstr_fd("minishell: exit: ", STDERR_FILENO);
-	ft_putstr_fd(arg, STDERR_FILENO);
-	ft_putendl_fd(": numeric argument required", STDERR_FILENO);
 }

--- a/srcs/utils/error_print.c
+++ b/srcs/utils/error_print.c
@@ -1,0 +1,69 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   error_print.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/03/05 20:27:33 by nfukada           #+#    #+#             */
+/*   Updated: 2021/03/05 20:29:51 by nfukada          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <errno.h>
+#include <string.h>
+#include "const.h"
+#include "utils.h"
+
+void	print_syntax_error(t_token *token)
+{
+	extern int	g_status;
+
+	ft_putstr_fd(
+		"minishell: syntax error near unexpected token `", STDERR_FILENO);
+	if (token)
+	{
+		ft_putstr_fd(token->data, STDERR_FILENO);
+	}
+	else
+	{
+		ft_putstr_fd("newline", STDERR_FILENO);
+	}
+	ft_putendl_fd("'", STDERR_FILENO);
+	g_status = STATUS_SYNTAX_ERROR;
+}
+
+void	print_token_error(t_token_state state)
+{
+	extern int	g_status;
+
+	if (state == STATE_IN_DQUOTE)
+		print_error("unexpected EOF while looking for matching `\"'", NULL);
+	if (state == STATE_IN_QUOTE)
+		print_error("unexpected EOF while looking for matching `''", NULL);
+	g_status = STATUS_TOKEN_ERROR;
+}
+
+void	print_bad_fd_error(int fd)
+{
+	char	*fd_str;
+
+	if (fd < 0)
+	{
+		print_error(strerror(errno), "file descriptor out of range");
+	}
+	else
+	{
+		if (!(fd_str = ft_itoa(fd)))
+			error_exit(NULL);
+		print_error(strerror(errno), fd_str);
+		free(fd_str);
+	}
+}
+
+void	print_numeric_argument_error(char *arg)
+{
+	ft_putstr_fd("minishell: exit: ", STDERR_FILENO);
+	ft_putstr_fd(arg, STDERR_FILENO);
+	ft_putendl_fd(": numeric argument required", STDERR_FILENO);
+}

--- a/srcs/utils/signal.c
+++ b/srcs/utils/signal.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/05 00:20:59 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/05 16:46:46 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/05 18:13:45 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,8 @@ void		handle_signal(int signal)
 	int			prev_errno;
 
 	prev_errno = errno;
-	ft_putstr_fd(ERASE_SIGNAL_MSG, STDERR_FILENO);
+	ft_putstr_fd(BACK_CURSOR, STDERR_FILENO);
+	ft_putstr_fd(CLEAR_FROM_CURSOR, STDERR_FILENO);
 	if (signal == SIGINT)
 	{
 		ft_putstr_fd("\n"SHELL_PROMPT, STDERR_FILENO);

--- a/srcs/utils/signal.c
+++ b/srcs/utils/signal.c
@@ -1,0 +1,43 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   signal.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/03/05 00:20:59 by nfukada           #+#    #+#             */
+/*   Updated: 2021/03/05 16:46:46 by nfukada          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <signal.h>
+#include <errno.h>
+#include "const.h"
+#include "utils.h"
+
+void		handle_signal(int signal)
+{
+	extern int	g_status;
+	int			prev_errno;
+
+	prev_errno = errno;
+	ft_putstr_fd(ERASE_SIGNAL_MSG, STDERR_FILENO);
+	if (signal == SIGINT)
+	{
+		ft_putstr_fd("\n"SHELL_PROMPT, STDERR_FILENO);
+		g_status = 1;
+	}
+	errno = prev_errno;
+}
+
+void		set_signal_handler(void (*func)(int))
+{
+	if (signal(SIGINT, func) == SIG_ERR)
+	{
+		error_exit(NULL);
+	}
+	if (signal(SIGQUIT, func) == SIG_ERR)
+	{
+		error_exit(NULL);
+	}
+}


### PR DESCRIPTION
Fix #61

## やったこと
Ctrl+D, Ctrl+C, Ctrl+\\を受け取った時の動作を実装しました。
bashの動作の詳細は #61 を参照してください。端末入力済みでCtrl+Dが来た以外は再現できてると思います。

### 1. Ctrl+D
Ctrl+Dはシグナルではなく、単にEOFを送るだけなので、gnlで0が返ってきた時の処理を追加しています。子プロセスでEOFが送られると、親でキャッチできるみたいです。

#### 動作
bashだと未入力の時にCtrl+Dが来たら、exitし、入力済みの場合は何もしない動作です。
minishellの場合、入力済みの場合、1回目のCtrl+Dでは何もせず、2回目ではexitします。
Ctrl+Dが来たら、そこから再度入力が始まる感じにしています。2回目は未入力扱いになってexitになります。
bashの動きを完全に再現するには、おそらくbonusもやらないといけないので、今回は対応していません。

### 2. Ctrl+C, Ctrl+\\
これらはシグナルというプロセスに送る信号です。`signal` という関数でシグナルが送られた時に特定の関数を実行できるようにしています（関数 `set_signal_handler` 内）。戻り値はセットした関数ポインタで、エラーの場合 `SIG_ERR` が返ってきます。

#### 2-1. 入力中
入力中にCtrl+C, Ctrl+\\をキャッチすると `handle_signal` という関数を呼び出します。やっていることは以下です。
- シグナルは`^\`, `^C` という文字が入力されてしまうので、エスケープシーケンスを使って文字を削除（参考：[ANSIエスケープシーケンス チートシート - Qiita](https://qiita.com/PruneMazui/items/8a023347772620025ad6)）。
- Ctrl+Cの時は、改行してminishellのプロンプトを表示します。

#### 2-2. コマンド実行中
子プロセスの場合、シグナルハンドラはデフォルトの動作になるようです。
Ctrl+C, Ctrl+\\ は、親、子、全てのプロセスに送られるため、子側をデフォルトの動作（`SIG_DFL`）に設定し、親側を無効（`SIG_IGN`）に設定しています。
親側は、入力ループで再度 `handle_signal` を設定するようにしています。
デフォルトの動作はCtrl+C, Ctrl+\\どちらもプロセスが終了します。

プロセスをwaitしたあと、statusからシグナルでプロセスが終了したのか判定し、stderrに出力を追加しています。

### 3. その他の変更
Makefile: `make` でなく `make debug` で `-g -fsanitize=address` をつけるようにしました（leaksコマンドが使えないため）。
norm対応でソースファイルを分割しました。

## テスト
手動で以下のテストケースを実行し、動作することを確認しています。
https://github.com/ToYeah/42_minishell/issues/61#issuecomment-791260783