### PR TITLE
$?を実装

### DIFF
--- a/includes/expander.h
+++ b/includes/expander.h
@@ -6,7 +6,7 @@
 /*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/21 08:24:01 by totaisei          #+#    #+#             */
-/*   Updated: 2021/02/22 12:21:18 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/07 13:34:20 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,5 +26,5 @@ typedef struct	s_expander
 void			expand_tokens(t_token **tokens);
 char			*create_expanded_str(const char *str, t_token_state state);
 char			*expand_env_var(char *input);
-
+char			*dup_env_value(char *name);
 #endif

--- a/srcs/expander/expand_var.c
+++ b/srcs/expander/expand_var.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   expand_var.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/22 12:03:39 by totaisei          #+#    #+#             */
-/*   Updated: 2021/02/27 23:28:22 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/07 13:36:40 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,5 +64,23 @@ char	*create_expanded_str(const char *str, t_token_state state)
 		(calc_escaped_value_len(str, esc_chars) + 1))))
 		error_exit(NULL);
 	copy_escaped_value(str, esc_chars, res);
+	return (res);
+}
+
+char	*dup_env_value(char *name)
+{
+	char		*res;
+	extern int	g_status;
+
+	if (ft_strcmp("?", name) == 0)
+	{
+		if (!(res = ft_itoa(g_status)))
+			error_exit(NULL);
+	}
+	else
+	{
+		if (!(res = ft_strdup(get_env_data(name))))
+			error_exit(NULL);
+	}
 	return (res);
 }

--- a/srcs/expander/expander.c
+++ b/srcs/expander/expander.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   expander.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/22 12:11:37 by totaisei          #+#    #+#             */
-/*   Updated: 2021/03/04 19:11:26 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/07 13:36:14 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,7 +63,7 @@ char			*extract_var_name(char *str)
 void			expand_var_in_str(t_expander *exper)
 {
 	char			*vars[4];
-	const char		*env_value;
+	char			*env_value;
 	size_t			after_var_index;
 
 	if (!(vars[VAR_NAME] = extract_var_name(&exper->str[exper->str_i + 1])))
@@ -71,7 +71,7 @@ void			expand_var_in_str(t_expander *exper)
 	if (ft_strlen(vars[VAR_NAME]) == 0)
 		return ;
 	exper->str[exper->str_i] = '\0';
-	env_value = get_env_data(vars[VAR_NAME]);
+	env_value = dup_env_value(vars[VAR_NAME]);
 	after_var_index = exper->str_i + ft_strlen(vars[VAR_NAME]) + 1;
 	if (!(vars[VALUE] = create_expanded_str(env_value, exper->state)) ||
 		!(vars[TMP] = ft_strjoin(exper->str, vars[VALUE])) ||
@@ -83,6 +83,7 @@ void			expand_var_in_str(t_expander *exper)
 	free(vars[VALUE]);
 	free(vars[VAR_NAME]);
 	free(vars[TMP]);
+	free(env_value);
 	free(exper->str);
 	exper->str = vars[RES];
 }


### PR DESCRIPTION
Fix　#68

`expander`以外で`$?`を参照することはないので、`expander`内で変数を参照する際`$?`の時だけ`itoa`、それ以外は`strdup`で対応しました