### PR TITLE
[utils] generate_environ: valueがNULLの環境変数を引き継がないよう修正

### DIFF
--- a/includes/utils.h
+++ b/includes/utils.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   utils.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 20:13:16 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/07 11:27:49 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/07 23:52:13 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,6 +43,7 @@ void			add_env(t_env **envs, t_env *new_env);
 void			del_env(t_env **envs, char *name);
 
 t_env			*get_last_env(t_env *envs);
+size_t			get_environ_size(t_env *envs);
 t_bool			can_generate_environ(t_env *env);
 t_env			*create_new_env(char *env_str);
 const char		*get_env_data(char *name);

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 20:13:16 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/07 23:52:13 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/08 00:03:56 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,7 +37,6 @@ void			print_error_filename(char *message,
 					char *command, char *file);
 
 t_env			*create_envs_from_environ(void);
-void			print_envs(t_env *envs);
 char			**generate_environ(t_env *envs);
 void			add_env(t_env **envs, t_env *new_env);
 void			del_env(t_env **envs, char *name);

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -43,7 +43,7 @@ void			add_env(t_env **envs, t_env *new_env);
 void			del_env(t_env **envs, char *name);
 
 t_env			*get_last_env(t_env *envs);
-size_t			get_env_size(t_env *envs);
+t_bool			can_generate_environ(t_env *env);
 t_env			*create_new_env(char *env_str);
 const char		*get_env_data(char *name);
 t_env			*get_env(const char *name);

--- a/srcs/utils/env.c
+++ b/srcs/utils/env.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/13 19:17:58 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/27 23:28:39 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/07 23:56:48 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,20 +50,22 @@ char	**generate_environ(t_env *envs)
 	size_t	env_size;
 	size_t	i;
 
-	env_size = get_env_size(envs);
-	environ = (char **)malloc(sizeof(char *) * (env_size + 1));
-	if (!environ)
+	env_size = get_environ_size(envs);
+	if (!(environ = (char **)malloc(sizeof(char *) * (env_size + 1))))
 		error_exit(NULL);
 	i = 0;
 	while (i < env_size)
 	{
-		if (!(environ[i] = ft_strjoin(envs->name, "=")))
-			error_exit(NULL);
-		tmp = environ[i];
-		if (!(environ[i] = ft_strjoin(environ[i], envs->value)))
-			error_exit(NULL);
-		free(tmp);
-		i++;
+		if (can_generate_environ(envs))
+		{
+			if (!(environ[i] = ft_strjoin(envs->name, "=")))
+				error_exit(NULL);
+			tmp = environ[i];
+			if (!(environ[i] = ft_strjoin(environ[i], envs->value)))
+				error_exit(NULL);
+			free(tmp);
+			i++;
+		}
 		envs = envs->next;
 	}
 	environ[i] = NULL;

--- a/srcs/utils/env.c
+++ b/srcs/utils/env.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/13 19:17:58 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/07 23:56:48 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/08 00:03:47 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,18 +29,6 @@ t_env	*create_envs_from_environ(void)
 		i++;
 	}
 	return (envs);
-}
-
-void	print_envs(t_env *envs)
-{
-	while (envs)
-	{
-		ft_putstr_fd(envs->name, STDOUT_FILENO);
-		ft_putchar_fd('=', STDOUT_FILENO);
-		ft_putstr_fd(envs->value, STDOUT_FILENO);
-		ft_putchar_fd('\n', STDOUT_FILENO);
-		envs = envs->next;
-	}
 }
 
 char	**generate_environ(t_env *envs)

--- a/srcs/utils/env_utils_get.c
+++ b/srcs/utils/env_utils_get.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/01 14:35:53 by totaisei          #+#    #+#             */
-/*   Updated: 2021/03/07 23:55:37 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/08 13:44:05 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,9 +15,11 @@
 
 t_bool		can_generate_environ(t_env *env)
 {
-	if (env->value)
-		return (TRUE);
-	return (FALSE);
+	if (env->value == NULL)
+		return (FALSE);
+	if (env->is_env == FALSE)
+		return (FALSE);
+	return (TRUE);
 }
 
 t_env		*get_last_env(t_env *envs)

--- a/srcs/utils/env_utils_get.c
+++ b/srcs/utils/env_utils_get.c
@@ -13,6 +13,13 @@
 #include "utils.h"
 #include "libft.h"
 
+t_bool		can_generate_environ(t_env *env)
+{
+	if (env->value)
+		return (TRUE);
+	return (FALSE);
+}
+
 t_env		*get_last_env(t_env *envs)
 {
 	t_env	*target;

--- a/srcs/utils/env_utils_get.c
+++ b/srcs/utils/env_utils_get.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env_utils_get.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/01 14:35:53 by totaisei          #+#    #+#             */
-/*   Updated: 2021/03/01 14:35:55 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/07 23:55:37 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,15 +32,16 @@ t_env		*get_last_env(t_env *envs)
 	return (target);
 }
 
-size_t		get_env_size(t_env *envs)
+size_t		get_environ_size(t_env *envs)
 {
 	size_t	size;
 
 	size = 0;
 	while (envs)
 	{
+		if (can_generate_environ(envs))
+			size++;
 		envs = envs->next;
-		size++;
 	}
 	return (size);
 }


### PR DESCRIPTION
Fix #69

## やったこと
generate_environ で valueがNULLの環境変数を含めないようにし、
子プロセスに引き継がないよう修正しました。

まだexportできないので、動作確認はできないです。

ついでに未使用変数 print_envs を削除しておきました。