### PR TITLE
パス探索の修正

### DIFF
--- a/includes/exec.h
+++ b/includes/exec.h
@@ -6,7 +6,7 @@
 /*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 20:07:01 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/07 11:27:24 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/08 08:44:25 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -85,6 +85,6 @@ void					wait_commands(t_command *command);
 char					*build_cmd_path(const char *cmd);
 
 t_bool					is_executable(const char *path);
-t_bool					is_command_exist(char *path, char **res);
+t_bool					is_command_exist(const char *path, char **res);
 
 #endif

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -6,7 +6,7 @@
 /*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 20:13:16 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/07 11:27:49 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/08 08:33:36 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,7 +50,6 @@ t_env			*get_env(const char *name);
 void			minishell_init(void);
 void			shlvl_init(void);
 char			*join_path(const char *prev, const char *next);
-char			*build_full_path(char *path, const char *cmd);
 char			*path_canonicalisation(char *path);
 t_bool			is_digit_str(char *str);
 t_bool			is_directory(const char *path);

--- a/srcs/exec/build_path.c
+++ b/srcs/exec/build_path.c
@@ -6,7 +6,7 @@
 /*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/23 11:40:22 by totaisei          #+#    #+#             */
-/*   Updated: 2021/03/08 08:04:18 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/08 08:44:32 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,7 +38,7 @@ char		*search_command_binary(const char *cmd)
 	if (!(split_path = ft_split(get_env_data("PATH"), ':')))
 		error_exit(NULL);
 	if (split_path[0] == NULL)
-		is_command_exist((char *)cmd, &res);
+		is_command_exist(cmd, &res);
 	while (split_path[index])
 	{
 		ft_safe_free_char(&path);

--- a/srcs/exec/build_path.c
+++ b/srcs/exec/build_path.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   build_path.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/23 11:40:22 by totaisei          #+#    #+#             */
-/*   Updated: 2021/03/03 21:57:04 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/08 08:04:18 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,15 +34,15 @@ char		*search_command_binary(const char *cmd)
 
 	index = 0;
 	res = NULL;
-	path = build_full_path("", cmd);
+	path = NULL;
 	if (!(split_path = ft_split(get_env_data("PATH"), ':')))
 		error_exit(NULL);
 	if (split_path[0] == NULL)
-		is_command_exist(path, &res);
+		is_command_exist((char *)cmd, &res);
 	while (split_path[index])
 	{
 		ft_safe_free_char(&path);
-		path = build_full_path(split_path[index], cmd);
+		path = join_path(split_path[index], cmd);
 		if (is_command_exist(path, &res) && !is_directory(path) &&
 			is_executable(path))
 			break ;

--- a/srcs/exec/build_path_stat.c
+++ b/srcs/exec/build_path_stat.c
@@ -6,7 +6,7 @@
 /*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/03 21:44:06 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/04 11:58:56 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/08 08:44:16 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ t_bool		is_executable(const char *path)
 	return (TRUE);
 }
 
-t_bool		is_command_exist(char *path, char **res)
+t_bool		is_command_exist(const char *path, char **res)
 {
 	t_stat buf;
 

--- a/srcs/utils/path_utils.c
+++ b/srcs/utils/path_utils.c
@@ -6,7 +6,7 @@
 /*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/25 15:32:52 by totaisei          #+#    #+#             */
-/*   Updated: 2021/03/05 12:12:58 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/08 08:33:30 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,33 +59,6 @@ char	*join_path(const char *prev, const char *next)
 	if (!(res = ft_strjoin(tmp, next)))
 		error_exit(NULL);
 	free(tmp);
-	return (res);
-}
-
-char	*build_full_path(char *path, const char *cmd)
-{
-	char *cwd;
-	char *res;
-	char *tmp;
-
-	if (*path == '/')
-		return (join_path(path, cmd));
-	if (!(cwd = getcwd(NULL, 0)))
-		return (NULL);
-	if (!(tmp = join_path(cwd, path)))
-	{
-		free(cwd);
-		return (NULL);
-	}
-	if (!(res = join_path(tmp, cmd)))
-	{
-		free(cwd);
-		free(tmp);
-		return (NULL);
-	}
-	free(cwd);
-	free(tmp);
-	correct_path(&res);
 	return (res);
 }
 

--- a/srcs/utils/path_utils.c
+++ b/srcs/utils/path_utils.c
@@ -6,40 +6,12 @@
 /*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/25 15:32:52 by totaisei          #+#    #+#             */
-/*   Updated: 2021/03/08 08:33:30 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/08 08:39:32 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "utils.h"
 #include "libft.h"
-
-void	correct_path(char **str)
-{
-	char	**split;
-	char	*res;
-	size_t	index;
-
-	if (!str || !*str)
-		return ;
-	index = 0;
-	split = NULL;
-	res = NULL;
-	if (!(split = ft_split(*str, '/')) ||
-		!(res = malloc(sizeof(char) * (ft_strlen(*str) + 1))))
-		error_exit(NULL);
-	ft_safe_free_char(str);
-	*str = res;
-	*res++ = '/';
-	while (split[index])
-	{
-		if (index != 0)
-			*res++ = '/';
-		res = ft_strcpy_forward(res, split[index]);
-		index++;
-	}
-	*res = '\0';
-	ft_safe_free_split(&split);
-}
 
 char	*join_path(const char *prev, const char *next)
 {


### PR DESCRIPTION
Fix #76

build_pathを行う際、結合の結果絶対パスが生まれないもの(PATHの中身が絶対パスでない)は絶対パスへの補正を行わず、そのままstatやexecにわたるよう変更しました

```
~/42_minishell>mkdir dir                           
~/42_minishell>cp /bin/ls dir/ 
~/42_minishell>cp /bin/ls dir/ls_2
~/42_minishell>chmod 000 dir/ls_2 
~/42_minishell>bash
%F{green}%~>%fexport export PATH=dir
%F{green}%~>%fls 
Makefilecdechofilelinkminishell-helpertest
Makefile.bakdidrenvincludeslspwdtests
adirexitlibftminishellsrcs
%F{green}%~>%fls_2
bash: dir/ls_2: Permission denied
%F{green}%~>%f./minishell
minishell > ls
Makefilecdechofilelinkminishell-helpertest
Makefile.bakdidrenvincludeslspwdtests
adirexitlibftminishellsrcs
minishell > ls_2 
minishell: dir/ls_2: Permission denied
```