### PR TITLE
[builtin]cdで//を指定されたときの挙動を修正

### DIFF
--- a/srcs/utils/path_canonicalisation.c
+++ b/srcs/utils/path_canonicalisation.c
@@ -6,7 +6,7 @@
 /*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/03 12:09:25 by totaisei          #+#    #+#             */
-/*   Updated: 2021/03/06 07:56:39 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/08 09:19:40 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,6 +54,21 @@ t_bool	cpy_canonical_path(char **split, char **res)
 	return (TRUE);
 }
 
+void	add_slash_path_front(char *path, char **res)
+{
+	char *added_res;
+
+	if (!path || !res || !*res)
+		return ;
+	if (ft_strncmp(path, "//", 2) == 0 && path[2] != '/')
+	{
+		if (!(added_res = ft_strjoin("/", *res)))
+			return error_exit(NULL);
+		ft_safe_free_char(res);
+		*res = added_res;
+	}
+}
+
 char	*path_canonicalisation(char *path)
 {
 	char			**split;
@@ -67,5 +82,6 @@ char	*path_canonicalisation(char *path)
 	if (!(cpy_canonical_path(split, &res)))
 		ft_safe_free_char(&res);
 	ft_safe_free_split(&split);
+	add_slash_path_front(path, &res);
 	return (res);
 }

--- a/srcs/utils/path_canonicalisation.c
+++ b/srcs/utils/path_canonicalisation.c
@@ -6,7 +6,7 @@
 /*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/03 12:09:25 by totaisei          #+#    #+#             */
-/*   Updated: 2021/03/08 09:19:40 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/08 10:44:10 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,7 +63,7 @@ void	add_slash_path_front(char *path, char **res)
 	if (ft_strncmp(path, "//", 2) == 0 && path[2] != '/')
 	{
 		if (!(added_res = ft_strjoin("/", *res)))
-			return error_exit(NULL);
+			error_exit(NULL);
 		ft_safe_free_char(res);
 		*res = added_res;
 	}

--- a/tests/cases/cd.txt
+++ b/tests/cases/cd.txt
@@ -56,3 +56,15 @@ mkdir a; cd a; pwd, export CDPATH="a"
 mkdir -p a/a; cd a; pwd, export CDPATH="a"
 mkdir -p a/b/c/d/e/f/g/h/i/; cd a/b/c/d/../../c/d/e/f/g/h/i/../../../g/h/i/../.././././../g/h/i/../../../../../../../c/d/../d/../d/e/../../d/e/.././././e/f/.//////../f/g/h/i/////../../../; pwd
 cd; cd ../../../../../././././../../../././../../../; pwd, export HOME="/"
+cd //; pwdl; cd //bin; pwd
+cd ///; pwdl; cd ///bin; pwd
+cd ////; pwdl; cd ////bin; pwd
+cd /////; pwdl; cd /////bin; pwd
+cd //////; pwdl; cd //////bin; pwd
+cd ///////; pwdl; cd ///////bin; pwd
+cd , export HOME=//
+cd , export HOME=//bin/..////////////bin/../
+cd , export HOME=///
+cd bin, export CDPATH=//
+cd bin, export CDPATH=//bin/..////////////bin/../
+cd bin, export CDPATH=///


### PR DESCRIPTION
Fix #80 

### やったこと

先頭の`/`が二個の場合のみ`//`になるようだったので、`path`を正規化した後入力値を見て先頭が`//`だった場合のみ`/`を追加する関数を作って対応しました

```
bash-3.2$ cd //
bash-3.2$ pwd
//
bash-3.2$ export PATH=//
bash-3.2$ cd 
bash: cd: HOME not set
bash-3.2$ export HOME=//
bash-3.2$ cd  
bash-3.2$ pwd
//
bash-3.2$ export CDPATH=//
bash-3.2$ cd bin
//bin
bash-3.2$ pwd
//bin
bash-3.2$ cd ///bin
bash-3.2$ pwd
/bin
bash-3.2$ cd ////bin
bash-3.2$ pwd       
/bin
bash-3.2$ cd //////bin
bash-3.2$ pwd
/bin
```

```
minishell > echo $PATH; echo $HOME; echo $CDPATH
//
//
//
minishell > cd //
minishell > pwd
//
minishell > cd //bin
minishell > pwd
//bin
minishell > cd 
minishell > pwd
//
minishell > cd bin
//bin
minishell > pwd
//bin
minishell > cd ///bin
minishell > pwd
/bin
minishell > cd ////bin
minishell > pwd
/bin
minishell > cd /////bin
minishell > pwd
/bin
```