### PR TITLE
execve失敗時の終了ステータスを修正

### DIFF
--- a/includes/exec.h
+++ b/includes/exec.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec.h                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 20:07:01 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/07 11:27:24 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/08 21:50:17 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -81,6 +81,7 @@ void					cleanup_redirects(t_command *command);
 
 t_bool					convert_tokens(t_command *command, char ***args);
 void					wait_commands(t_command *command);
+void					handle_execve_error(char *path);
 
 char					*build_cmd_path(const char *cmd);
 

--- a/srcs/exec/build_path.c
+++ b/srcs/exec/build_path.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/23 11:40:22 by totaisei          #+#    #+#             */
-/*   Updated: 2021/03/03 21:57:04 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/08 21:34:33 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,16 +59,6 @@ static void	check_cmd_path(const char *cmd, const char *path)
 	{
 		print_error("command not found", (char *)cmd);
 		exit(STATUS_CMD_NOT_FOUND);
-	}
-	if (is_directory(path))
-	{
-		print_error("is a directory", (char *)path);
-		exit(STATUS_CMD_NOT_EXECUTABLE);
-	}
-	if (!is_executable(path))
-	{
-		print_error("Permission denied", (char *)path);
-		exit(STATUS_CMD_NOT_EXECUTABLE);
 	}
 }
 

--- a/srcs/exec/build_path_stat.c
+++ b/srcs/exec/build_path_stat.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   build_path_stat.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/03 21:44:06 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/04 11:58:56 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/08 21:57:22 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,8 +18,10 @@ t_bool		is_executable(const char *path)
 	t_stat	path_stat;
 
 	if (stat(path, &path_stat) == -1)
-		return (TRUE);
+		return (FALSE);
 	if ((path_stat.st_mode & S_IXUSR) != S_IXUSR)
+		return (FALSE);
+	if ((path_stat.st_mode & S_IRUSR) != S_IRUSR)
 		return (FALSE);
 	return (TRUE);
 }

--- a/srcs/exec/command.c
+++ b/srcs/exec/command.c
@@ -6,12 +6,15 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/22 17:08:55 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/06 22:01:38 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/08 21:49:50 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <signal.h>
 #include <sys/wait.h>
+#include <errno.h>
+#include <string.h>
+#include "const.h"
 #include "exec.h"
 #include "expander.h"
 
@@ -97,4 +100,25 @@ void		wait_commands(t_command *command)
 	if (has_child == FALSE)
 		return ;
 	handle_command_status(status, catch_sigint);
+}
+
+void		handle_execve_error(char *path)
+{
+	int	status;
+
+	if (errno == ENOENT)
+		status = STATUS_CMD_NOT_FOUND;
+	else
+		status = STATUS_CMD_NOT_EXECUTABLE;
+	if (is_directory(path))
+	{
+		print_error("is a directory", path);
+		exit(status);
+	}
+	if (errno == ENOEXEC && !is_executable(path))
+		errno = EACCES;
+	if (errno == ENOEXEC)
+		exit(EXIT_SUCCESS);
+	print_error(strerror(errno), path);
+	exit(status);
 }

--- a/srcs/exec/exec_command.c
+++ b/srcs/exec/exec_command.c
@@ -6,14 +6,11 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/27 20:16:45 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/08 18:12:20 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/08 21:49:43 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include <errno.h>
-#include <string.h>
 #include <signal.h>
-#include "const.h"
 #include "builtin.h"
 #include "exec.h"
 
@@ -27,13 +24,7 @@ static void		exec_binary(char **args)
 	path = build_cmd_path(args[0]);
 	if (execve(path, args, generate_environ(g_envs)) < 0)
 	{
-		if (errno == ENOEXEC)
-			exit(EXIT_SUCCESS);
-		print_error(strerror(errno), path);
-		if (errno == ENOENT)
-			exit(STATUS_CMD_NOT_FOUND);
-		else
-			exit(STATUS_CMD_NOT_EXECUTABLE);
+		handle_execve_error(path);
 	}
 	free(path);
 	ft_safe_free_split(&envs);

--- a/srcs/exec/exec_command.c
+++ b/srcs/exec/exec_command.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/27 20:16:45 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/06 22:02:01 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/08 17:46:30 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,13 +27,11 @@ static void		exec_binary(char **args)
 	path = build_cmd_path(args[0]);
 	if (execve(path, args, generate_environ(g_envs)) < 0)
 	{
+		print_error(strerror(errno), path);
 		if (errno == ENOENT)
-		{
-			print_error(strerror(errno), path);
 			exit(STATUS_CMD_NOT_FOUND);
-		}
 		else
-			error_exit(path);
+			exit(STATUS_CMD_NOT_EXECUTABLE);
 	}
 	free(path);
 	ft_safe_free_split(&envs);

--- a/srcs/exec/exec_command.c
+++ b/srcs/exec/exec_command.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/27 20:16:45 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/08 17:46:30 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/08 18:12:20 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,6 +27,8 @@ static void		exec_binary(char **args)
 	path = build_cmd_path(args[0]);
 	if (execve(path, args, generate_environ(g_envs)) < 0)
 	{
+		if (errno == ENOEXEC)
+			exit(EXIT_SUCCESS);
 		print_error(strerror(errno), path);
 		if (errno == ENOENT)
 			exit(STATUS_CMD_NOT_FOUND);

--- a/tests/cases/simple_command.txt
+++ b/tests/cases/simple_command.txt
@@ -13,6 +13,12 @@ no_such_file
 /bin/no_such_dir/file
 perm, touch perm; chmod 000 perm
 ./perm, touch perm; chmod 000 perm
+perm, touch perm; chmod 100 perm
+./perm, touch perm; chmod 100 perm
+perm, touch perm; chmod 300 perm
+./perm, touch perm; chmod 300 perm
+perm, touch perm; chmod 500 perm
+./perm, touch perm; chmod 500 perm
 ./empty, touch empty; chmod +x empty
 dir, mkdir dir
 ./dir, mkdir dir

--- a/tests/cases/simple_command.txt
+++ b/tests/cases/simple_command.txt
@@ -9,8 +9,11 @@ ls | grep a | grep c, touch aa ab ac
 echo hello world | cat
 no_such_file
 ./no_such_file
+/bin/ls/no_such_file
+/bin/no_such_dir/file
 perm, touch perm; chmod 000 perm
 ./perm, touch perm; chmod 000 perm
+./empty, touch empty; chmod +x empty
 dir, mkdir dir
 ./dir, mkdir dir
 ./exe, printf "#!/bin/bash\necho 42" > exe; chmod +x exe; ln -s exe sym; chmod -h -x sym

--- a/tests/grademe.sh
+++ b/tests/grademe.sh
@@ -181,5 +181,6 @@ show_results () {
 	fi
 }
 
+make -C "${MINISHELL_DIR}"
 run_all_tests $@
 show_results

--- a/tests/grademe.sh
+++ b/tests/grademe.sh
@@ -80,6 +80,8 @@ prepare_test_dir () {
 	fi
 	mkdir -p ${TEST_DIR}
 	cd ${TEST_DIR}
+	eval "${SETUP_CMD}"
+	cd ${TEST_DIR}
 }
 
 set_minishell_path () {


### PR DESCRIPTION
Fix #77

## やったこと
1. execveで `errno` が `ENOEXEC` の場合、エラーメッセージを表示せず0でexitするよう修正。
   - 例：実行フォーマットでないファイル（空ファイルなど）が渡された時。
2. execveで `ENOENT` 以外の `errno`だった場合126でexitするよう修正。
   - 例：ファイルがディレクトリ扱いの時（ `Not a directory` ）

### テストケース
ケース | 説明
-- | --
/bin/ls/no_such_file | 絶対パスでファイルがディレクトリとして指定されている場合。
/bin/no_such_dir/file | 絶対パスでディレクトリが存在しない場合。
./empty, touch empty; chmod +x empty | 実行フォーマットでないファイルが指定された場合。
