### PR TITLE
parserのメモリリーク修正（echo | |のようなケース）

### DIFF
--- a/includes/parser.h
+++ b/includes/parser.h
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/18 10:55:56 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/25 20:45:57 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/10 21:40:43 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,7 +43,7 @@ t_bool			is_redirect_token(t_token *token);
 t_node			*add_parent_node(t_node_type type, t_node *left, t_node *right);
 t_node			*create_command_node(t_parse_info *info);
 void			set_command_args(t_command *command, t_token **tokens);
-void			del_node_list(t_node *node);
+void			del_node_list(t_node **node);
 
 void			print_nodes(t_node *node);
 void			print_command_args(t_token *args, int fd);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/10 18:50:22 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/05 21:35:07 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/10 21:43:24 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,7 +35,7 @@ void	run_commandline(char *line)
 	else
 		exec_nodes(nodes);
 	del_token_list(&start_token);
-	del_node_list(nodes);
+	del_node_list(&nodes);
 }
 
 void	process_input(int *gnl_result)

--- a/srcs/parser/node.c
+++ b/srcs/parser/node.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/18 12:06:22 by nfukada           #+#    #+#             */
-/*   Updated: 2021/02/27 23:28:29 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/10 21:41:25 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,17 +58,18 @@ t_node	*create_command_node(t_parse_info *info)
 	return (node);
 }
 
-void	del_node_list(t_node *node)
+void	del_node_list(t_node **node)
 {
-	if (!node)
+	if (!node || !*node)
 		return ;
-	if (node->type == NODE_COMMAND && node->command)
+	if ((*node)->type == NODE_COMMAND && (*node)->command)
 	{
-		del_token_list(&node->command->args);
-		del_redirect_list(&node->command->redirects);
-		free(node->command);
+		del_token_list(&(*node)->command->args);
+		del_redirect_list(&(*node)->command->redirects);
+		free((*node)->command);
 	}
-	del_node_list(node->left);
-	del_node_list(node->right);
-	free(node);
+	del_node_list(&(*node)->left);
+	del_node_list(&(*node)->right);
+	free(*node);
+	*node = NULL;
 }

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -58,8 +58,7 @@ static t_bool	parse_command(
 		{
 			if (parse_io_redirect(tokens, *node) == FALSE)
 			{
-				del_node_list(*node);
-				*node = NULL;
+				del_node_list(node);
 				return (FALSE);
 			}
 		}

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/17 01:11:20 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/01 12:21:08 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/10 21:41:50 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,7 +66,10 @@ static t_bool	parse_command(
 			break ;
 	}
 	if (!(*node)->command->args && !(*node)->command->redirects)
+	{
+		del_node_list(node);
 		return (FALSE);
+	}
 	return (TRUE);
 }
 


### PR DESCRIPTION
Fix #87

## やったこと
parser でのメモリリークを修正しました。
作った node を解放できていない箇所がありました。

norm対策で、nodeを削除する関数（`del_node_list`）をNULL埋めするよう変更しています。
再帰を使っていますが、末端からnodeを見たあと nodeをNULL埋めするので、影響はないはずです。