### PR TITLE
fix(utils): シェル起動時OLDPWD, PWD, SHLVLでis_envが設定されず不定なのを修正

### DIFF
--- a/srcs/utils/shell_init.c
+++ b/srcs/utils/shell_init.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   shell_init.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/28 11:07:08 by totaisei          #+#    #+#             */
-/*   Updated: 2021/03/01 15:01:19 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/12 18:06:20 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,6 +45,7 @@ void	old_pwd_init(void)
 		}
 		old_pwd_env->value = NULL;
 		old_pwd_env->next = NULL;
+		old_pwd_env->is_env = TRUE;
 		add_env(&g_envs, old_pwd_env);
 	}
 	ft_safe_free_char(&(old_pwd_env->value));
@@ -83,6 +84,7 @@ void	pwd_init(void)
 		}
 		pwd_env->value = NULL;
 		pwd_env->next = NULL;
+		pwd_env->is_env = TRUE;
 		add_env(&g_envs, pwd_env);
 	}
 	pwd_value_init(pwd_env);

--- a/srcs/utils/shlvl_init.c
+++ b/srcs/utils/shlvl_init.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   shlvl_init.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/28 18:27:08 by totaisei          #+#    #+#             */
-/*   Updated: 2021/03/06 12:11:18 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/12 18:06:29 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -96,6 +96,7 @@ void	shlvl_init(void)
 			error_exit(NULL);
 		}
 		shlvl_env->next = NULL;
+		shlvl_env->is_env = TRUE;
 		add_env(&g_envs, shlvl_env);
 		return ;
 	}


### PR DESCRIPTION
Fix #94

## やったこと
シェル起動時、OLDPWD, PWD, SHLVLでis_envが設定されておらず、値が不定なのを修正しました。

原因、水平展開は #94 を参照ください。