### PR TITLE
export PATH=''がcommand not foundになるバグを修正

### DIFF
--- a/libft/ft_strncmp.c
+++ b/libft/ft_strncmp.c
@@ -6,7 +6,7 @@
 /*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/10/08 22:02:56 by totaisei          #+#    #+#             */
-/*   Updated: 2021/03/11 04:33:13 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/12 12:15:38 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,9 +67,9 @@ int	ft_strcmp(char *s1, char *s2)
 		{
 			return (s1[i] - s2[i]);
 		}
-		i++;
 		if (!(s1[i]) && !(s2[i]))
 			break ;
+		i++;
 	}
 	return (0);
 }

--- a/srcs/exec/build_path.c
+++ b/srcs/exec/build_path.c
@@ -6,7 +6,7 @@
 /*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/23 11:40:22 by totaisei          #+#    #+#             */
-/*   Updated: 2021/03/11 13:40:04 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/12 12:14:58 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,30 +25,42 @@ t_cmd_type	judge_cmd_type(const char *str)
 		return (COMMAND);
 }
 
-char		*search_command_binary(const char *cmd)
+void		try_search_command(char **split_path, char **res, const char *cmd)
 {
-	char	**split_path;
 	int		index;
-	char	*res;
 	char	*path;
 
 	index = 0;
-	res = NULL;
 	path = NULL;
-	if (!(split_path = get_colon_units(get_env_data("PATH"), ".")))
-		error_exit(NULL);
-	if (split_path[0] == NULL)
-		is_command_exist(cmd, &res);
 	while (split_path[index])
 	{
 		ft_safe_free_char(&path);
 		path = join_path(split_path[index], cmd);
-		if (is_command_exist(path, &res) && !is_directory(path) &&
+		if (is_command_exist(path, res) && !is_directory(path) &&
 			is_executable(path))
 			break ;
 		index++;
 	}
 	ft_safe_free_char(&path);
+}
+
+char		*search_command_binary(const char *cmd)
+{
+	char	**split_path;
+	char	*res;
+	const char	*env_value;
+
+	res = NULL;
+	env_value = get_env_data("PATH");
+	if (ft_strcmp((char *)env_value, "") == 0)
+	{
+		if (!(res = ft_strdup(cmd)))
+			error_exit(NULL);
+		return (res);
+	}
+	if (!(split_path = get_colon_units(env_value, ".")))
+		error_exit(NULL);
+	try_search_command(split_path, &res, cmd);
 	ft_safe_free_split(&split_path);
 	return (res);
 }

--- a/srcs/exec/build_path.c
+++ b/srcs/exec/build_path.c
@@ -6,7 +6,7 @@
 /*   By: totaisei <totaisei@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/23 11:40:22 by totaisei          #+#    #+#             */
-/*   Updated: 2021/03/12 12:14:58 by totaisei         ###   ########.fr       */
+/*   Updated: 2021/03/12 12:36:28 by totaisei         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,8 +46,8 @@ void		try_search_command(char **split_path, char **res, const char *cmd)
 
 char		*search_command_binary(const char *cmd)
 {
-	char	**split_path;
-	char	*res;
+	char		**split_path;
+	char		*res;
 	const char	*env_value;
 
 	res = NULL;

--- a/tests/cases/simple_command.txt
+++ b/tests/cases/simple_command.txt
@@ -33,3 +33,8 @@ export PATH=":/bin" ; ls , cp /bin/ls .; chmod 000 ls;
 export PATH="::/bin::" ; ls , cp /bin/ls .; chmod 000 ls;
 export PATH="/bin:" ; ls , cp /bin/ls .; chmod 000 ls;
 export PATH="hello:" ; ls , cp /bin/ls .; chmod 000 ls;
+export PATH=""; nosuchfile
+export PATH=''; nosuchfile
+unset PATH; nosuchfile
+unset PATH; export PATH; nosuchfile
+unset PATH; export PATH=; nosuchfile


### PR DESCRIPTION
### やったこと
**ft_strcmpのバグ修正**
`""`と`""`の比較を行う際、引き算の結果が`0`だった時無条件にインクリメントしていたため、インクリメントを行う前に両方が`\0`であったらbreakの処理が効くようにしました。

**search_command_binary内の処理を分割**
whileを回して検索する処理を、`try_search_command`に処理を分けました。
`search_command_binary`側では、`env_search`の結果が""だった時、`cmd`の複製文字列を`return`する処理を追加しました。
