### PR TITLE
ctrl+Dの挙動を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2021/02/10 18:36:52 by nfukada           #+#    #+#              #
-#    Updated: 2021/03/12 16:10:51 by nfukada          ###   ########.fr        #
+#    Updated: 2021/03/14 00:04:09 by nfukada          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -37,7 +37,7 @@ LIBS		:= -lft -L$(LIBFT_DIR)
 CC			:= gcc
 CFLAGS		:= -Wall -Werror -Wextra $(INC)
 
-.PHONY: all clean fclean re bonus debug norm srcs
+.PHONY: all clean fclean re bonus debug leaks norm srcs
 
 all		: $(NAME)
 

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/10 18:50:22 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/12 12:44:13 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/14 00:13:23 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,38 +39,51 @@ void	run_commandline(char *line)
 	del_node_list(&nodes);
 }
 
-void	process_input(int *gnl_result)
+void	handle_eof(char *line, char *buf_line)
+{
+	if (line[0] == '\0' && buf_line == NULL)
+	{
+		ft_putendl_fd("exit", STDERR_FILENO);
+		exit(g_status);
+	}
+	ft_putstr_fd(CLEAR_FROM_CURSOR, STDERR_FILENO);
+}
+
+void	process_input(int *gnl_result, char **buf_line)
 {
 	char	*line;
+	char	*tmp;
 
 	if (*gnl_result)
 		ft_putstr_fd(SHELL_PROMPT, STDERR_FILENO);
 	if ((*gnl_result = ft_get_next_line(STDIN_FILENO, &line)) < 0)
 		error_exit(NULL);
 	if (*gnl_result == 0)
-	{
-		if (line[0] == '\0')
-		{
-			ft_putendl_fd("exit", STDERR_FILENO);
-			exit(g_status);
-		}
-		ft_putstr_fd(CLEAR_FROM_CURSOR, STDERR_FILENO);
-	}
+		handle_eof(line, *buf_line);
+	tmp = *buf_line;
+	if ((*buf_line = ft_strjoin(*buf_line, line)) == NULL)
+		error_exit(NULL);
+	free(tmp);
 	if (*gnl_result)
-		run_commandline(line);
+	{
+		run_commandline(*buf_line);
+		ft_safe_free_char(buf_line);
+	}
 	free(line);
 }
 
 void	loop_shell(void)
 {
 	int		gnl_result;
+	char	*buf_line;
 
 	gnl_result = 1;
+	buf_line = NULL;
 	while (TRUE)
 	{
 		g_interrupted = FALSE;
 		set_signal_handler(handle_signal);
-		process_input(&gnl_result);
+		process_input(&gnl_result, &buf_line);
 	}
 }
 

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/10 18:50:22 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/14 00:13:23 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/14 00:21:31 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,8 +54,6 @@ void	process_input(int *gnl_result, char **buf_line)
 	char	*line;
 	char	*tmp;
 
-	if (*gnl_result)
-		ft_putstr_fd(SHELL_PROMPT, STDERR_FILENO);
 	if ((*gnl_result = ft_get_next_line(STDIN_FILENO, &line)) < 0)
 		error_exit(NULL);
 	if (*gnl_result == 0)
@@ -85,6 +83,8 @@ void	loop_shell(void)
 	{
 		g_interrupted = FALSE;
 		set_signal_handler(handle_signal);
+		if (gnl_result)
+			ft_putstr_fd(SHELL_PROMPT, STDERR_FILENO);
 		process_input(&gnl_result, &buf_line);
 	}
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/10 18:50:22 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/14 00:21:31 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/15 20:54:15 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,7 @@ void	run_commandline(char *line)
 
 void	handle_eof(char *line, char *buf_line)
 {
-	if (line[0] == '\0' && buf_line == NULL)
+	if (line[0] == '\0' && (buf_line == NULL || g_interrupted == TRUE))
 	{
 		ft_putendl_fd("exit", STDERR_FILENO);
 		exit(g_status);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -21,6 +21,7 @@ t_env	*g_envs;
 int		g_status;
 char	*g_pwd;
 t_bool	g_interactive;
+t_bool	g_interrupted;
 
 void	run_commandline(char *line)
 {
@@ -67,6 +68,7 @@ void	loop_shell(void)
 	gnl_result = 1;
 	while (TRUE)
 	{
+		g_interrupted = FALSE;
 		set_signal_handler(handle_signal);
 		process_input(&gnl_result);
 	}

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -60,6 +60,8 @@ void	process_input(int *gnl_result, char **buf_line)
 		error_exit(NULL);
 	if (*gnl_result == 0)
 		handle_eof(line, *buf_line);
+	if (g_interrupted == TRUE)
+		ft_safe_free_char(buf_line);
 	tmp = *buf_line;
 	if ((*buf_line = ft_strjoin(*buf_line, line)) == NULL)
 		error_exit(NULL);

--- a/srcs/utils/signal.c
+++ b/srcs/utils/signal.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/05 00:20:59 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/05 18:13:45 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/13 23:57:14 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,8 +17,9 @@
 
 void		handle_signal(int signal)
 {
-	extern int	g_status;
-	int			prev_errno;
+	extern int		g_status;
+	extern t_bool	g_interrupted;
+	int				prev_errno;
 
 	prev_errno = errno;
 	ft_putstr_fd(BACK_CURSOR, STDERR_FILENO);
@@ -27,6 +28,7 @@ void		handle_signal(int signal)
 	{
 		ft_putstr_fd("\n"SHELL_PROMPT, STDERR_FILENO);
 		g_status = 1;
+		g_interrupted = TRUE;
 	}
 	errno = prev_errno;
 }


### PR DESCRIPTION
## やったこと
入力中 ctrl+D を押した時、入力した文字を破棄してしまう問題を修正しました！

1. `loop_shell()` ： `buf_line` を追加
   `loop_shell()` に `buf_line` を追加し、ctrl+Dが押された時 `buf_line` に 入力文字列 `line` が join されていくようになっています。
   コマンド実行時、 line ではなく `buf_line` を実行するようにしました。

2. global変数 `g_interrupted` 追加
   SIGINT を受け取ると `buf_line` が残ったままになってしまうため、global変数 `g_interrupted` をフラグとして追加して、SIGINTを受け取ったかTRUE/FALSEでわかるようにしました。
   SIGINT を受け取ったら、ハンドラでTRUEにし、`process_input` でTRUEだったら `buf_line` をfreeします。

3. リファクタリング
   関数が長くなったため、 `handle_eof` にEOFの処理を切り出しました。

4. Makefileの微修正
    leaks を .PHONYに入れ忘れていたので入れました。

## テスト
https://github.com/ToYeah/42_minishell/issues/61#issuecomment-791260783 の Ctrl+Dのケースを実施し全てOK。

追加で以下のケースを実施。全てOK。

No | 条件 | 入力 | 出力 | 終了ステータス
-- | -- | -- | -- | --
19 | ls | Ctrl + D -> Ctrl + C | bash-3.2$ ls<br>bash-3.2$ | 1
20 | aaaaa<Ctrl + D>bbbb<Ctrl + D>\<Enter> | <>の箇所入力 | bash-3.2$ aaaaabbbb<br>bash: aaaaabbbb: command not found | 127
21 | echo <Ctrl + D>hello\<Enter> | <>の箇所入力 | bash-3.2$ echo hello<br>hello | 0
22 | echo hello<Ctrl + D><Ctrl + \\>\<Enter> | <>の箇所入力 | bash-3.2$ echo hello<br>hello | 0
23 | <1023文字分入力><Ctrl + D><任意の文字入力>\<Enter> | <>の箇所入力 | 1-24文字を超えて文字入力できること、Enterで入力文字が反映されていることを確認 | - |
24 | ls<Ctrl + D><Ctrl + D> | <>の箇所入力 | Ctrl + D 入力後、コマンドが実行されないことを確認 | - |

## 気になっていること
global変数が多すぎるので、構造体 t_shell を作って、そこに既存のglobal変数を入れ、 g_shell で持たせた方がいいのかなと思ってます。
`g_interrupted` と `g_interactive` の名前がちょっと似てるので、もっと違う命名ができたらと思っています。
案：
- `g_interrupted`: `g_catched_signal`
- `g_interactive`: `g_shell_interactive`
