### PR TITLE
exit 0 0; cmdでcmdが実行されないよう修正

### DIFF
--- a/srcs/builtin/mini_exit.c
+++ b/srcs/builtin/mini_exit.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/04 14:59:01 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/05 20:55:41 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/16 13:36:01 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,6 +33,7 @@ int				exec_exit(char **args)
 {
 	extern int		g_status;
 	extern t_bool	g_interactive;
+	extern t_bool	g_exited;
 	int				i;
 	int				status;
 
@@ -45,8 +46,8 @@ int				exec_exit(char **args)
 		exit(g_status);
 	errno = 0;
 	status = ft_atoi(args[i]);
-	if (has_error(args, i) == TRUE)
-		return (EXIT_FAILURE);
-	exit(status);
+	if (has_error(args, i) == FALSE)
+		exit(status);
+	g_exited = TRUE;
 	return (EXIT_FAILURE);
 }

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/12 17:59:52 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/05 20:36:29 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/16 13:36:27 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,7 +57,9 @@ static void		exec_list(t_node *nodes)
 
 void			exec_nodes(t_node *nodes)
 {
-	if (!nodes)
+	extern t_bool g_exited;
+
+	if (!nodes || g_exited == TRUE)
 	{
 		return ;
 	}

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: nfukada <nfukada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/10 18:50:22 by nfukada           #+#    #+#             */
-/*   Updated: 2021/03/15 20:54:15 by nfukada          ###   ########.fr       */
+/*   Updated: 2021/03/16 13:33:10 by nfukada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,7 @@ int		g_status;
 char	*g_pwd;
 t_bool	g_interactive;
 t_bool	g_interrupted;
+t_bool	g_exited;
 
 void	run_commandline(char *line)
 {
@@ -82,6 +83,7 @@ void	loop_shell(void)
 	while (TRUE)
 	{
 		g_interrupted = FALSE;
+		g_exited = FALSE;
 		set_signal_handler(handle_signal);
 		if (gnl_result)
 			ft_putstr_fd(SHELL_PROMPT, STDERR_FILENO);

--- a/tests/cases/exit.txt
+++ b/tests/cases/exit.txt
@@ -21,5 +21,6 @@ exit +
 exit -
 exit "          "
 exit 0 0;
+exit 0 0; exit;
 exit 0 0; echo "this message should not be displayed" 2> file; ls
 exit 0 0 | echo hello

--- a/tests/cases/exit.txt
+++ b/tests/cases/exit.txt
@@ -20,3 +20,6 @@ exit 1a
 exit +
 exit -
 exit "          "
+exit 0 0;
+exit 0 0; echo "this message should not be displayed" 2> file; ls
+exit 0 0 | echo hello


### PR DESCRIPTION
Fix #111

## やったこと
`exit 0 0; cmd` でcmdが実行されないよう修正しました。
global変数 `g_exited` を追加し、shellのループで FALSE に初期化、 exitが呼び出された場合 TRUE になるようにしています。
木からコマンドを実行する際、`g_exited` が TRUEならコマンドを実行せず終了します。

パイプなど子プロセスで exit が呼び出された場合、子プロセスのglobal変数は書き換わりますが、親には伝播しません。

## テストケース
- exit 0 0; cmd
- exit 0 0 | cmd
- exit 0 0;

の3ケースを追加しています。